### PR TITLE
define getLayoutInfo's return type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,5 +36,7 @@ module.exports = {
         '@typescript-eslint/no-non-null-assertion': 0,
         'no-param-reassign': 0,
         '@typescript-eslint/no-object-literal-type-assertion': 0,
+        'no-empty-function': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
     },
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "eslint": "^6.5.1",
         "eslint-config-airbnb": "^18.0.1",
         "eslint-config-prettier": "^6.4.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "2.18.2",
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-prettier": "^3.1.1",
         "eslint-plugin-react": "^7.16.0",

--- a/packages/graphin-site/docs/api/extend.en.md
+++ b/packages/graphin-site/docs/api/extend.en.md
@@ -7,12 +7,12 @@ The property `extend` of  component `<Graphin/>` is used to extend layout, NodeS
 
 |   Property    | Type                                                           | Required | Description       |
 | --------- | -------------------------------------------------------------- | -------- | ---------- |
-| layout    | (graphin: [Graphin](), prevProps: [GraphinProps](/zh/docs/api/graphin#props)) => [ExendLayout](#extendlayout)[ ]  | no       | custom Layout |
+| layout    | (graphin: [Graphin](), prevProps: [GraphinProps](/zh/docs/api/graphin#props)) => [ExtendLayout](#extendlayout)[ ]  | no       | custom Layout |
 | nodeShape | (node: [Node](/zh/docs/api/graphin#node)) => [ExtendNodeShape](#extendnodeshape)[ ] | no       | custom Node |
 | marker    | ( ) => [ExtendMarker](#extendmarker)[ ]         | no       | custom Icon |
 
 
-### ExendLayout
+### ExtendLayout
 
 Configuration of custom layout
 

--- a/packages/graphin-site/docs/api/extend.zh.md
+++ b/packages/graphin-site/docs/api/extend.zh.md
@@ -7,12 +7,12 @@ order: 3
 
 |   属性    | 类型                                                           | 是否必选 | 说明       |
 | --------- | -------------------------------------------------------------- | -------- | ---------- |
-| layout    | (graphin: [Graphin](), prevProps: [GraphinProps](/zh/docs/api/graphin#props)) => [ExendLayout](#extendlayout)[ ]  | 否       | 自定义布局 |
+| layout    | (graphin: [Graphin](), prevProps: [GraphinProps](/zh/docs/api/graphin#props)) => [ExtendLayout](#extendlayout)[ ]  | 否       | 自定义布局 |
 | nodeShape | (node: [Node](/zh/docs/api/graphin#node)) => [ExtendNodeShape](#extendnodeshape)[ ] | 否       | 自定义节点 |
 | marker    | ( ) => [ExtendMarker](#extendmarker)[ ]         | 否       | 自定义图标 |
 | icon   | ( ) => [ExtendIcon](#extendicon)[ ]         | 否       | 自定义图标（iconfont 形式） |
 
-### ExendLayout
+### ExtendLayout
 
 自定义布局配置
 

--- a/packages/graphin/src/Graphin.tsx
+++ b/packages/graphin/src/Graphin.tsx
@@ -12,7 +12,16 @@ import apisController from './apis';
 import eventController from './events/index';
 
 /** types  */
-import { GraphinProps, GraphinState, ExtendedGraphOptions, GraphType, ForceSimulation, Data, Layout } from './types';
+import {
+    GraphinProps,
+    GraphinState,
+    ExtendedGraphOptions,
+    GraphType,
+    ForceSimulation,
+    Data,
+    Layout,
+    ExtendLayout,
+} from './types';
 
 /** utils */
 import debug from './utils/debug';

--- a/packages/graphin/src/controller/layout/index.tsx
+++ b/packages/graphin/src/controller/layout/index.tsx
@@ -1,5 +1,5 @@
 import dataChecking from './dataChecking';
-import { GraphinProps, Data, ForceSimulation, ExendLayout } from '../../types';
+import { GraphinProps, Data, ForceSimulation, ExtendLayout } from '../../types';
 import Graphin from '../../Graphin';
 import defaultLayouts, { LayoutOption } from './defaultLayouts';
 
@@ -8,7 +8,7 @@ interface LayoutParams {
     prevProps?: GraphinProps;
 }
 
-const layoutInfo = (layouts: ExendLayout[]) => {
+const layoutInfo = (layouts: ExtendLayout[]) => {
     return layouts.map(item => {
         const { desc, name, icon } = item;
         return {

--- a/packages/graphin/src/types.ts
+++ b/packages/graphin/src/types.ts
@@ -230,7 +230,7 @@ export interface ExtendNodeShape {
     name: string;
     render: NodeShapeFunction;
 }
-export interface ExendLayout {
+export interface ExtendLayout {
     /** 布局名称，唯一标示 */
     name: string;
     /** 布局展示名称 */
@@ -286,7 +286,7 @@ export interface GraphinProps {
     layout?: Layout;
 
     extend?: {
-        layout?: (graphin: Graphin, prevProps: GraphinProps) => ExendLayout[];
+        layout?: (graphin: Graphin, prevProps: GraphinProps) => ExtendLayout[];
         nodeShape?: () => ExtendNodeShape[];
         marker?: () => ExtendMarker[];
         icon?: () => ExtendIcon[];


### PR DESCRIPTION
1. define getLayoutInfo's return type
2. "eslint-plugin-import" is broken after upgrade to 2.19.1, lock it temporarily.