### PR TITLE
fix: extend ReactNodeShape dark style

### DIFF
--- a/packages/graphin-studio/src/Extend/RectNodeShape.ts
+++ b/packages/graphin-studio/src/Extend/RectNodeShape.ts
@@ -142,26 +142,27 @@ const renderRectNode: NodeShapeFunction = (node: Node) => {
                     lineWidth: 6,
                 },
             },
+            'highlight.dark': {
+                'rect-container': {
+                    fill: style.dark,
+                    stroke: style.dark,
+                    lineWidth: 0,
+                },
+                'node-icon': {
+                    fill: style.dark,
+                },
+                'text-desc': {
+                    fill: '#eee',
+                },
+                badge: {
+                    fill: style.dark,
+                },
+                'badge-text': {
+                    fill: style.dark,
+                },
+            },
         },
-        'highlight.dark': {
-            'rect-container': {
-                fill: style.dark,
-                stroke: style.dark,
-                lineWidth: 0,
-            },
-            'node-icon': {
-                fill: style.dark,
-            },
-            'text-desc': {
-                fill: '#eee',
-            },
-            badge: {
-                fill: style.dark,
-            },
-            'badge-text': {
-                fill: style.dark,
-            },
-        },
+        
     };
 };
 export default renderRectNode;


### PR DESCRIPTION
fix 'highlight.dark' style not working issue when node state is dark