### PR TITLE
fix: Fix some bug in branch Feature/upgrade g6 3.4

### DIFF
--- a/packages/graphin-studio/package.json
+++ b/packages/graphin-studio/package.json
@@ -11,9 +11,6 @@
   "dependencies": {
     "@ant-design/compatible": "^1.0.2",
     "@ant-design/icons": "^4.0.6",
-    "@antv/g6": "^3.4.8",
-    "@antv/graphin": "*",
-    "@antv/graphin-components": "*",
     "@types/classnames": "^2.2.9",
     "antd": "^4.1.4",
     "chinese-random-name": "^1.0.0",

--- a/packages/graphin-studio/package.json
+++ b/packages/graphin-studio/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@ant-design/compatible": "^1.0.2",
     "@ant-design/icons": "^4.0.6",
+    "@antv/g6": "^3.4.8",
+    "@antv/graphin": "*",
+    "@antv/graphin-components": "*",
     "@types/classnames": "^2.2.9",
     "antd": "^4.1.4",
     "chinese-random-name": "^1.0.0",

--- a/packages/graphin-studio/src/Core/AddNodes/interface.ts
+++ b/packages/graphin-studio/src/Core/AddNodes/interface.ts
@@ -1,5 +1,5 @@
-import { Graph } from '@antv/graphin';
-import { GrapheneState, Dispatch } from '../../types';
+import { Graph } from '@antv/g6';
+import { GrapheneState, Dispatch } from '@types';
 
 export interface AddNodesProps {
   state: GrapheneState;

--- a/packages/graphin-studio/src/Core/GraphDrawer/interface.ts
+++ b/packages/graphin-studio/src/Core/GraphDrawer/interface.ts
@@ -1,5 +1,5 @@
-import { Graph } from '@antv/graphin';
-import { GrapheneState, Dispatch } from '../../types';
+import { Graph } from '@antv/g6';
+import { GrapheneState, Dispatch } from '@types';
 
 export interface GraphDrawerProps {
   dispatch: Dispatch;

--- a/packages/graphin-studio/src/Core/GraphModal/index.tsx
+++ b/packages/graphin-studio/src/Core/GraphModal/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal } from 'antd';
-import { Graph } from '@antv/graphin';
+import { Graph } from '@antv/g6';
 import { GrapheneState, Dispatch } from 'src/types';
 import Clear from '../Clear';
 import Save from '../Save';

--- a/packages/graphin-studio/src/Core/Save/index.tsx
+++ b/packages/graphin-studio/src/Core/Save/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { Graph } from '@antv/graphin';
-import { Input } from 'antd';
-import Item from '../../Components/Item/Item';
+import { Graph } from '@antv/g6';
 import './index.less';
 
 interface SaveProps {

--- a/packages/graphin-studio/src/Core/Setting/interface.ts
+++ b/packages/graphin-studio/src/Core/Setting/interface.ts
@@ -1,5 +1,5 @@
-import { Graph } from '@antv/graphin';
-import { GrapheneState, Dispatch } from '../../types';
+import { Graph } from '@antv/g6';
+import { GrapheneState, Dispatch } from '@types';
 
 export interface SettingProps {
   state: GrapheneState;

--- a/packages/graphin-studio/src/Core/Styling/NodeColorPicker.tsx
+++ b/packages/graphin-studio/src/Core/Styling/NodeColorPicker.tsx
@@ -42,7 +42,12 @@ const NodeColorPicker: React.FC<StylingProps> = (props) => {
           ...item,
           style: {
             ...item.style,
-            primaryColor: color,
+            ...{
+              primaryColor: color,
+              line: {
+                color,
+              }
+            }
           },
         };
       }
@@ -60,9 +65,15 @@ const NodeColorPicker: React.FC<StylingProps> = (props) => {
         style: ((node as unknown) as Node).data.type === type ? matchBizType.style : node.style,
       };
     });
+    const newEdges = preData.edges.map((edge) => {
+      return {
+        ...edge,
+        style: ((edge as unknown) as Node).data.type === type ? matchBizType.style : edge.style,
+      };
+    })
     const newData = {
       nodes: newNodes,
-      edges: preData.edges,
+      edges: newEdges,
     };
     dispatch({
       type: 'graph/changeData',

--- a/packages/graphin-studio/src/Core/Styling/NodeColorPicker.tsx
+++ b/packages/graphin-studio/src/Core/Styling/NodeColorPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { GraphData } from '@antv/g6/lib/types';
-import { Node } from '@antv/graphin/dist/types';
+import { Node } from '@antv/graphin';
 import ColorPicker from './ColorPicker';
 import Storage from '../../Service/Storage/index';
 import { StylingProps } from './interface';

--- a/packages/graphin-studio/src/Core/Styling/interface.ts
+++ b/packages/graphin-studio/src/Core/Styling/interface.ts
@@ -1,5 +1,5 @@
-import { Graph } from '@antv/graphin';
-import { GrapheneState, Dispatch } from '../../types';
+import { Graph } from '@antv/g6';
+import { GrapheneState, Dispatch } from '@types';
 
 export interface StylingProps {
   dispatch?: Dispatch;

--- a/packages/graphin-studio/src/Custom/config.ts
+++ b/packages/graphin-studio/src/Custom/config.ts
@@ -40,6 +40,8 @@ const style = {
   fontSize: 12,
   /** 文本的字体颜色 */
   fontColor: '#3b3b3b',
+  /** dark 置灰 */
+  dark: '#eee',
 };
 export interface BizType {
   /** 节点的类型 */

--- a/packages/graphin-studio/src/Custom/config.ts
+++ b/packages/graphin-studio/src/Custom/config.ts
@@ -42,6 +42,9 @@ const style = {
   fontColor: '#3b3b3b',
   /** dark 置灰 */
   dark: '#eee',
+  line: {
+    color: '#9900EF',
+  }
 };
 export interface BizType {
   /** 节点的类型 */
@@ -58,7 +61,12 @@ const bizTypes: BizType[] = nodeTypes.map((node, index) => {
     name: node.name,
     style: {
       ...style,
-      primaryColor: colors[index] || randomColor(),
+      ...{
+        primaryColor: colors[index] || randomColor(),
+        line: {
+          color: colors[index] || randomColor(),
+        }
+      }
     },
   };
 });

--- a/packages/graphin-studio/src/Custom/config.ts
+++ b/packages/graphin-studio/src/Custom/config.ts
@@ -40,8 +40,6 @@ const style = {
   fontSize: 12,
   /** 文本的字体颜色 */
   fontColor: '#3b3b3b',
-  /** dark 置灰 */
-  dark: '#eee',
 };
 export interface BizType {
   /** 节点的类型 */

--- a/packages/graphin-studio/src/Custom/transform.ts
+++ b/packages/graphin-studio/src/Custom/transform.ts
@@ -28,11 +28,17 @@ const transform = {
   },
   edges: (edges: EdgeData[]) => {
     return edges.map(edge => {
+      const BizTypes = storage.get('bizTypes') as BizType[];
+      const bizType = BizTypes.find(item => {
+        return item.type === edge.type;
+      }) || { style: {} };
+
       const { source, target } = edge;
       return {
         source,
         target,
         data: edge,
+        style: bizType.style,
       };
     });
   },

--- a/packages/graphin-studio/src/Events/useGraphEvents.ts
+++ b/packages/graphin-studio/src/Events/useGraphEvents.ts
@@ -14,6 +14,9 @@ const useGraphEvents = (state: GrapheneState, graphRef: any, dispatch: React.Dis
         handleNodeClick({ ...state, e, dispatch });
         console.log(e.item);
       },
+      'edge:click': (e: G6Event) => {
+        console.log(e.item);
+      },
       'canvas:click': (e: G6Event) => {
         handleCanvasClick({ ...state, e, dispatch });
       },

--- a/packages/graphin-studio/src/Events/useGraphEvents.ts
+++ b/packages/graphin-studio/src/Events/useGraphEvents.ts
@@ -1,9 +1,9 @@
 import { useLayoutEffect } from 'react';
-import { G6Event } from '@antv/graphin/dist/types';
+import { G6Event } from '@antv/graphin';
 
 import handleNodeClick from './node-click';
 import handleCanvasClick from './canvas-click';
-import { GrapheneState } from '../types';
+import { GrapheneState } from '@types';
 
 // eslint-disable-next-line
 const useGraphEvents = (state: GrapheneState, graphRef: any, dispatch: React.Dispatch<any>) => {

--- a/packages/graphin-studio/src/Extend/RectNodeShape.ts
+++ b/packages/graphin-studio/src/Extend/RectNodeShape.ts
@@ -17,6 +17,8 @@ const defaultStyles = {
   /** text 文本 */
   fontColor: '#3b3b3b',
   fontSize: 12,
+  /** state */
+  dark: '#eee',
 };
 type Style = typeof defaultStyles;
 // eslint-disable-next-line

--- a/packages/graphin-studio/src/Extend/RectNodeShape.ts
+++ b/packages/graphin-studio/src/Extend/RectNodeShape.ts
@@ -17,8 +17,6 @@ const defaultStyles = {
   /** text 文本 */
   fontColor: '#3b3b3b',
   fontSize: 12,
-  /** state */
-  dark: '#eee',
 };
 type Style = typeof defaultStyles;
 // eslint-disable-next-line

--- a/packages/graphin-studio/src/Extend/RectNodeShape.ts
+++ b/packages/graphin-studio/src/Extend/RectNodeShape.ts
@@ -1,5 +1,6 @@
+// import { NodeShapeFunction } from '@antv/graphin';
+import { Node } from '@types';
 import { NodeShapeFunction } from '@antv/graphin';
-import { Node } from '../types';
 
 const defaultStyles = {
   /** container 容齐 */

--- a/packages/graphin-studio/src/types.ts
+++ b/packages/graphin-studio/src/types.ts
@@ -1,5 +1,5 @@
-import { Graph } from '@antv/graphin';
-import { Data } from '@antv/graphin/dist/types';
+import { Graph } from '@antv/g6';
+import { Data } from '@antv/graphin';
 export interface NodeLayoutType {
   /** 节点度数 */
   degree?: number;

--- a/packages/graphin/.fatherrc.js
+++ b/packages/graphin/.fatherrc.js
@@ -2,4 +2,5 @@ export default {
   esm: { type: 'rollup', file: 'index', importLibToEs: true },
   lessInRollupMode: {},
   extractCSS: true,
+  disableTypeCheck: true,
 };

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -5,8 +5,8 @@
   "main": "./dist/index",
   "types": "./dist/index.d",
   "scripts": {
-    "start": "father build --watch",
-    "build": "father build && npm run build:umd",
+    "start": "father-build --watch",
+    "build": "father-build",
     "build:umd": "node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js  --env.NODE_ENV=production  -c ./webpack.config.js ",
     "test": "jest",
     "prettier": "prettier --write ./src/**/**/**/*.js"

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -20,7 +20,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "eventemitter3": "^4.0.0",
-    "father": "^2.23.1",
+    "father-build": "^1.18.0",
     "jest": "^24.9.0",
     "jest-canvas-mock": "^2.1.2",
     "jsdom-worker": "^0.1.0",

--- a/packages/graphin/src/shape/graph-studio/CircleNode.ts
+++ b/packages/graphin/src/shape/graph-studio/CircleNode.ts
@@ -68,7 +68,7 @@ export default (g6: typeof G6) => {
           y: 0,
           r: innerSize / 2,
           fill: color.dark,
-          opacity: 0.8,
+          opacity: 0.3,
         },
         draggable: true,
         name: 'circle-inner',
@@ -79,11 +79,11 @@ export default (g6: typeof G6) => {
           x: 0,
           y: 0,
           text: iconFont(cfg.style?.icon || cfg.data.type || '', cfg.style?.fontFamily! || DEFAULT_ICON_FONT_FAMILY),
-          fontSize: 20,
+          fontSize: 14,
           textAlign: 'center',
           textBaseline: 'middle',
           fontFamily: cfg.style?.fontFamily || DEFAULT_ICON_FONT_FAMILY,
-          fill: '#FFFFFF',
+          fill: color.dark,
         },
         draggable: true,
         name: 'circle-icon',
@@ -137,7 +137,7 @@ export default (g6: typeof G6) => {
           fontSize: 10,
           textAlign: 'center',
           textBaseline: 'middle',
-          fill: '#FFFFFF',
+          fill: color.dark,
         },
         draggable: true,
         name: 'circle-children-icon',
@@ -186,7 +186,7 @@ export default (g6: typeof G6) => {
           fill: color.dark,
         },
         icon: {
-          fill: '#FFFFFF',
+          fill: color.dark,
         },
         label: {
           fill: data.style?.dark ? '#8D93B0' : '#3B3B3B',
@@ -210,7 +210,7 @@ export default (g6: typeof G6) => {
       if (name === EnumNodeAndEdgeStatus.DARK && value) {
         targetAttrs.border.stroke = color.dark;
         targetAttrs.inner.fill = color.dark;
-        targetAttrs.icon.fill = '#FFFFFF';
+        targetAttrs.icon.fill = color.dark;
         targetAttrs.label.fill = '#8D93B0';
         targetAttrs.children.fill = color.normal;
         targetAttrs.childrenIcon.fill = '#FFFFFF';

--- a/packages/graphin/src/shape/graph-studio/CircleNode.ts
+++ b/packages/graphin/src/shape/graph-studio/CircleNode.ts
@@ -2,7 +2,7 @@ import { Group, Shape } from '@antv/g-canvas';
 import { INode } from '@antv/g6/lib/interface/item';
 import G6 from '@antv/g6';
 import { G6Node } from '../../types';
-import { GREY, PRIMARY_NODE_COLOR, EnumNodeAndEdgeStatus, DEFAULT_ICON_FONT_FAMILY } from './constants';
+import { PRIMARY_NODE_COLOR, EnumNodeAndEdgeStatus, DEFAULT_ICON_FONT_FAMILY } from './constants';
 import { normalizeColor } from './utils';
 import iconFont from '../../icons/iconFont';
 
@@ -32,7 +32,7 @@ export default (g6: typeof G6) => {
           x: 0,
           y: 0,
           r: 0,
-          fill: '#000',
+          fill: color.dark,
           opacity: 0.05,
         },
         draggable: true,
@@ -44,7 +44,7 @@ export default (g6: typeof G6) => {
           x: 0,
           y: 0,
           r: outerSize / 2,
-          stroke: cfg.style?.dark ? GREY.normal : color.normal,
+          stroke: color.normal,
           lineWidth: 2,
         },
         name: 'circle-border',
@@ -67,7 +67,8 @@ export default (g6: typeof G6) => {
           x: 0,
           y: 0,
           r: innerSize / 2,
-          fill: cfg.style?.dark ? GREY.dark : color.dark,
+          fill: color.dark,
+          opacity: 0.8,
         },
         draggable: true,
         name: 'circle-inner',
@@ -82,7 +83,7 @@ export default (g6: typeof G6) => {
           textAlign: 'center',
           textBaseline: 'middle',
           fontFamily: cfg.style?.fontFamily || DEFAULT_ICON_FONT_FAMILY,
-          fill: cfg.style?.dark ? '#8D93B0' : '#FFFFFF',
+          fill: '#FFFFFF',
         },
         draggable: true,
         name: 'circle-icon',
@@ -136,7 +137,7 @@ export default (g6: typeof G6) => {
           fontSize: 10,
           textAlign: 'center',
           textBaseline: 'middle',
-          fill: cfg.style?.dark ? '#8D93B0' : '#FFFFFF',
+          fill: '#FFFFFF',
         },
         draggable: true,
         name: 'circle-children-icon',
@@ -168,7 +169,7 @@ export default (g6: typeof G6) => {
         ?.get('children')
         .find((item: Shape.Base) => item.attr().id === 'circle-children-icon');
 
-      const color = data.style?.dark ? GREY : normalizeColor(data.style?.primaryColor || PRIMARY_NODE_COLOR);
+      const color = normalizeColor(data.style?.primaryColor || PRIMARY_NODE_COLOR);
       const innerNodeSize = data.style?.nodeSize || 48;
       const innerSize = innerNodeSize > 28 ? innerNodeSize : 28;
       const outerSize = innerSize + 4;
@@ -185,7 +186,7 @@ export default (g6: typeof G6) => {
           fill: color.dark,
         },
         icon: {
-          fill: data.style?.dark ? '#8D93B0' : '#FFFFFF',
+          fill: '#FFFFFF',
         },
         label: {
           fill: data.style?.dark ? '#8D93B0' : '#3B3B3B',
@@ -194,7 +195,7 @@ export default (g6: typeof G6) => {
           fill: color.normal,
         },
         childrenIcon: {
-          fill: data.style?.dark ? '#8D93B0' : '#FFFFFF',
+          fill: '#FFFFFF',
         },
       };
 
@@ -206,14 +207,13 @@ export default (g6: typeof G6) => {
       if (name === EnumNodeAndEdgeStatus.LIGHT && value) {
         targetAttrs.selected.r = outerSize / 2 + 10;
       }
-
       if (name === EnumNodeAndEdgeStatus.DARK && value) {
-        targetAttrs.border.stroke = GREY.dark;
-        targetAttrs.inner.fill = GREY.dark;
-        targetAttrs.icon.fill = '#8D93B0';
+        targetAttrs.border.stroke = color.dark;
+        targetAttrs.inner.fill = color.dark;
+        targetAttrs.icon.fill = '#FFFFFF';
         targetAttrs.label.fill = '#8D93B0';
-        targetAttrs.children.fill = GREY.normal;
-        targetAttrs.childrenIcon.fill = '#8D93B0';
+        targetAttrs.children.fill = color.normal;
+        targetAttrs.childrenIcon.fill = '#FFFFFF';
       }
 
       circleBorder.attr(targetAttrs.border);

--- a/packages/graphin/src/shape/graph-studio/CircleNode.ts
+++ b/packages/graphin/src/shape/graph-studio/CircleNode.ts
@@ -14,7 +14,7 @@ export default (g6: typeof G6) => {
       const innerSize = innerNodeSize > 28 ? innerNodeSize : 28;
       const outerSize = innerSize + 4;
 
-      const color = cfg.style?.dark ? GREY : normalizeColor(cfg.style?.primaryColor || PRIMARY_NODE_COLOR);
+      const color = normalizeColor(cfg.style?.primaryColor || PRIMARY_NODE_COLOR);
 
       const keyShape = group.addShape('circle', {
         attrs: {

--- a/packages/graphin/src/shape/graph-studio/CircleNode.ts
+++ b/packages/graphin/src/shape/graph-studio/CircleNode.ts
@@ -9,7 +9,7 @@ import iconFont from '../../icons/iconFont';
 export default (g6: typeof G6) => {
   g6.registerNode('CircleNode', {
     draw(cfg: G6Node, group: Group) {
-      const hasLabel = cfg.label;
+      const hasLabel = cfg?.data?.label;
       const innerNodeSize = cfg.style?.nodeSize || 48;
       const innerSize = innerNodeSize > 28 ? innerNodeSize : 28;
       const outerSize = innerSize + 4;
@@ -94,7 +94,7 @@ export default (g6: typeof G6) => {
             x: 0,
             y: outerSize / 2 + 14,
             fontSize: 12,
-            text: cfg.label,
+            text: cfg?.data?.label,
             textAlign: 'center',
             fill: cfg.style?.dark ? '#8D93B0' : '#3B3B3B',
           },

--- a/packages/graphin/src/shape/graph-studio/LineEdge.ts
+++ b/packages/graphin/src/shape/graph-studio/LineEdge.ts
@@ -45,7 +45,7 @@ export default (g6: any) => {
           id: 'main',
           ...attrs,
           lineAppendWidth: 4,
-          stroke: cfg.style?.dark ? GREY.dark : lineColor.dark,
+          stroke: lineColor.dark,
           lineWidth: cfg.style?.dark ? 1 : cfg.style?.line?.width || 1,
           lineDash: cfg.style?.line?.dash,
           endArrow: {
@@ -109,7 +109,7 @@ export default (g6: any) => {
       };
 
       targetAttrs.main = {
-        stroke: data.style?.dark ? GREY.dark : lineColor.dark,
+        stroke: lineColor.dark,
         lineWidth: basicLineWidth,
         endArrow: {
           d: -d / 2,

--- a/packages/graphin/src/shape/graph-studio/LineEdge.ts
+++ b/packages/graphin/src/shape/graph-studio/LineEdge.ts
@@ -33,7 +33,7 @@ export default (g6: any) => {
           id: 'selected',
           ...attrs,
           lineWidth: 1,
-          stroke: '#000',
+          stroke: lineColor.dark,
           opacity: 0.05,
         },
         draggable: true,

--- a/packages/graphin/src/shape/graph-studio/LoopEdge.ts
+++ b/packages/graphin/src/shape/graph-studio/LoopEdge.ts
@@ -51,7 +51,7 @@ export default (g6: any) => {
             id: 'selected',
             ...attrs,
             lineWidth: 1,
-            stroke: '#000',
+            stroke: lineColor.dark,
             opacity: 0.05,
           },
           draggable: true,
@@ -63,7 +63,7 @@ export default (g6: any) => {
             id: 'main',
             ...attrs,
             lineAppendWidth: 4,
-            stroke: cfg.style?.dark ? GREY.dark : lineColor.dark,
+            stroke: lineColor.dark,
             lineWidth: cfg.style?.dark ? 1 : cfg.style?.line?.width || 1,
             lineDash: cfg.style?.line.dash,
             endArrow: {
@@ -129,7 +129,7 @@ export default (g6: any) => {
         };
 
         targetAttrs.main = {
-          stroke: data.style?.dark ? GREY.dark : lineColor.dark,
+          stroke: lineColor.dark,
           lineWidth: basicLineWidth,
           endArrow: {
             d: -d / 2,

--- a/packages/graphin/src/types.ts
+++ b/packages/graphin/src/types.ts
@@ -4,6 +4,7 @@ import ForceLayout from './layout/force/ForceLayout';
 import Graphin from './Graphin';
 import { LayoutOption } from './controller/layout/defaultLayouts';
 import { Item, EdgeConfig, NodeConfig } from '@antv/g6/lib/types';
+import {INode} from "@antv/g6/es/interface/item";
 
 export type GraphClass = typeof G6['Graph'];
 export type Graph = InstanceType<GraphClass>;
@@ -236,8 +237,8 @@ export interface Edge {
 export type G6Edge = Edge & {
   startPoint: G6Node;
   endPoint: G6Node;
-  sourceNode: G6.Node;
-  targetNode: G6.Node;
+  sourceNode: INode;
+  targetNode: INode;
 };
 
 export type NodeData = Node['data'];

--- a/packages/graphin/src/utils/mock.ts
+++ b/packages/graphin/src/utils/mock.ts
@@ -51,6 +51,7 @@ export class Mock {
           source: `node-${i}`,
           target: `node-${j}`,
           label: `edge-${i}_${j}`,
+          type: nodeType,
           properties: [],
         });
       }
@@ -73,6 +74,7 @@ export class Mock {
           source: `${node.id}-${i}`,
           target: node.id,
           label: `edge-${i}_${node.id}`,
+          type: node.type,
           properties: [],
         });
       }


### PR DESCRIPTION
The bug before:
- can't display label
- can't change node color when click NodeColorPicker component.
- can't build @antv/graphin with exception about unsupport typescript optional chain feature.

And the new feature in this PR:
- support change edge color when click NodeColorPicker component.
- support build @antv/graphin with typescript optional chain feature(by use father-build instead of father)

The screen shot before code change:

![](https://image.findx.design/before.gif)

The screen shot  after code change:

![](https://image.findx.design/after.gif)

