### PR TITLE
fix: #150 (resolved)-legend not updating on props update

### DIFF
--- a/packages/graphin-components/src/components/legend/__tests__/index.test.tsx
+++ b/packages/graphin-components/src/components/legend/__tests__/index.test.tsx
@@ -1,13 +1,28 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Graphin from '@antv/graphin/src/Graphin';
-import { render } from '@testing-library/react';
+import { render, screen, waitFor, waitForDomChange, fireEvent } from '@testing-library/react';
 
 import '@testing-library/jest-dom/extend-expect';
 
 import Legend, { LegendOption } from '../index';
 
+const onChangeMock = jest.fn();
+
+const MockComponent = (props: { options: LegendOption[] }) => {
+  const { options: propOptions } = props;
+  const [options, setOptions] = useState<LegendOption[]>([]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setOptions(propOptions);
+    }, 3000);
+  }, [propOptions]);
+
+  return <Legend options={options} onChange={onChangeMock} />;
+};
+
 describe('<Legend />', () => {
-  it('You shall pass', () => {
+  it('Legend should render correctly', () => {
     const data = {
       nodes: [],
       edges: [],
@@ -33,5 +48,57 @@ describe('<Legend />', () => {
         <Legend options={options} onChange={() => {}} />
       </Graphin>,
     );
+
+    expect(screen.getByText('人群')).toBeInTheDocument();
+    expect(screen.getByText('公司')).toBeInTheDocument();
+  });
+
+  it('Legend should update on props update', async () => {
+    const options: LegendOption[] = [
+      {
+        label: '人群',
+        value: 'person',
+        color: 'red',
+      },
+      {
+        label: '公司',
+        value: 'company',
+        color: 'blue',
+      },
+    ];
+
+    const { container } = render(<MockComponent options={options} />);
+
+    expect(screen.queryByText('人群')).toBeNull();
+
+    expect(screen.queryByText('公司')).toBeNull();
+
+    await waitForDomChange({ container });
+    expect(screen.getByText('人群')).toBeInTheDocument();
+    expect(screen.getByText('公司')).toBeInTheDocument();
+  });
+
+  it('OnChange should be fired correctly on legend click', async () => {
+    const options: LegendOption[] = [
+      {
+        label: '人群',
+        value: 'person',
+        color: 'red',
+      },
+      {
+        label: '公司',
+        value: 'company',
+        color: 'blue',
+      },
+    ];
+
+    const { container } = render(<MockComponent options={options} />);
+
+    await waitForDomChange({ container });
+    fireEvent.click(screen.getByText('人群'));
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(screen.getByText('人群'));
+
+    expect(onChangeMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/graphin-components/src/components/legend/index.tsx
+++ b/packages/graphin-components/src/components/legend/index.tsx
@@ -30,7 +30,8 @@ const Legend: React.FunctionComponent<LegendProps> = (props) => {
     });
   const [options, setOptions] = React.useState(mergedOptions(originalOptions));
 
-  useEffect(() => setOptions(originalOptions), [originalOptions]);
+  useEffect(() => setOptions(mergedOptions(originalOptions)), [originalOptions]);
+
   const handleClick = (option: LegendOption) => {
     const checkedValue = { ...option, checked: !option.checked };
     const result = options.map((c) => {

--- a/packages/graphin-components/src/components/legend/index.tsx
+++ b/packages/graphin-components/src/components/legend/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './index.less';
 
 export interface LegendOption {
@@ -16,21 +16,24 @@ export interface LegendProps {
   onChange?: (checked: LegendOption, newOptions: LegendOption[], props: any) => any; // eslint-disable-line
 }
 
-const Legend: React.FunctionComponent<LegendProps> = props => {
-  const { onChange = () => {} } = props;
+const Legend: React.FunctionComponent<LegendProps> = (props) => {
+  const { onChange = () => {}, options: originalOptions } = props;
   // eslint-disable-next-line react/destructuring-assignment
-  const mergedOptions = props.options.map(c => {
-    const { checked } = c;
-    return {
-      ...c,
-      checked: typeof checked === 'boolean' ? checked : true,
-    };
-  });
-  const [options, setOptions] = React.useState(mergedOptions);
 
+  const mergedOptions: { (options: LegendOption[]): LegendOption[] } = (options) =>
+    options.map((c) => {
+      const { checked } = c;
+      return {
+        ...c,
+        checked: typeof checked === 'boolean' ? checked : true,
+      };
+    });
+  const [options, setOptions] = React.useState(mergedOptions(originalOptions));
+
+  useEffect(() => setOptions(originalOptions), [originalOptions]);
   const handleClick = (option: LegendOption) => {
     const checkedValue = { ...option, checked: !option.checked };
-    const result = options.map(c => {
+    const result = options.map((c) => {
       const matched = c.value === option.value;
       return matched ? checkedValue : c;
     });


### PR DESCRIPTION
Resolves : [ #150 ](https://github.com/antvis/Graphin/issues/150)
**Previous State :** 
1. when props were updating  Legend was not updating. Here is a stackblitz to demonstrate that. 
https://stackblitz.com/edit/react-mv6hzc

2. There were no test written to test the legend.

**Resolution :** 
1. Now as props update the state of the Legend will also be updated. All the new props are not getting transferred to the state because of the addition of useEffect which will file if props.options get updated

2. New passing tests have been added with 100% coverage for Legend file.

