### PR TITLE
fix: toolbar zoom add parameters for mouse wheel 

### DIFF
--- a/packages/graphin-components/src/components/toolbar/index.tsx
+++ b/packages/graphin-components/src/components/toolbar/index.tsx
@@ -71,17 +71,17 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
 
   const [fullscreen, toggleFullscreen] = useFullscreen(graphinContainer);
   const [zoom, handleZoom] = useZoom(1);
-  const handleGraphZoom = (isZoom: boolean) => {
+  const handleGraphZoom = (isZoom: boolean, curZoom) => {
     const center = {
       x: width / 2,
       y: height / 2,
     };
     const newZoom = handleZoom(isZoom);
-    if (graph) graph.zoomTo(newZoom, center);
+    graph?.zoomTo(newZoom, center);
   };
 
   const historyInfo = history.getInfo();
-
+  const curZoom = graph?.getZoom().toFixed(2);
   let buttonCfg: MenuItem[] = [
     {
       id: 'fullscreen',
@@ -95,14 +95,14 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
       name: '放大',
       icon: <ZoomInOutlined />,
       disabled: zoom >= MAX_ZOOM,
-      action: () => handleGraphZoom(true),
+      action: () => handleGraphZoom(true, curZoom),
     },
     {
       id: 'zoomOut',
       name: '缩小',
       icon: <ZoomOutOutlined />,
       disabled: zoom <= MIN_ZOOM,
-      action: () => handleGraphZoom(false),
+      action: () => handleGraphZoom(false, curZoom),
     },
     {
       id: 'undo',

--- a/packages/graphin-components/src/components/toolbar/useZoom.ts
+++ b/packages/graphin-components/src/components/toolbar/useZoom.ts
@@ -12,7 +12,7 @@ const getNextZoom = (curZoom, isZoomIn, minZoom, maxZoom) => {
   return zoom;
 };
 interface FunHandleZoom {
-  (isZoomIn: boolean): number;
+  (isZoomIn: boolean, curZoom?: number): number;
 }
 interface FunUseZoom {
   (initZoom: number): [number, FunHandleZoom];
@@ -20,8 +20,8 @@ interface FunUseZoom {
 
 const useZoom: FunUseZoom = (initZoom = 1) => {
   const [zoom, setZoom] = useState(initZoom);
-  const handleZoom: FunHandleZoom = isZoomIn => {
-    const newZoom = getNextZoom(zoom, isZoomIn, MIN_ZOOM, MAX_ZOOM);
+  const handleZoom: FunHandleZoom = (isZoomIn, curZoom) => {
+    const newZoom = getNextZoom(curZoom || zoom, isZoomIn, MIN_ZOOM, MAX_ZOOM);
     setZoom(newZoom);
     return newZoom;
   };


### PR DESCRIPTION
计入toolbar鼠标滚轮对于Zoom的影响
用graph?.getZoom()得到当前滚轮的ratio
避免操作情况出现：
1. 用户鼠标缩小或增大
2. 用toolbar 的 + / -  调节后， 图片跳回鼠标缩小或增大之前的 ratio