### PR TITLE
导出需要的Typescript类型

### DIFF
--- a/packages/graphin/docs/render/theme/setting-ts.tsx
+++ b/packages/graphin/docs/render/theme/setting-ts.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import Graphin, { Utils, Behaviors, GraphinData, IUserNode, Layout, ThemeType } from '@antv/graphin';
+import iconLoader from '@antv/graphin-icons';
+import { Row, Col } from 'antd';
+
+const { ZoomCanvas } = Behaviors;
+const data: GraphinData = Utils.mock(4).circle().graphin();
+
+const layout: Layout = {
+  type: 'concentric',
+};
+
+const icons = Graphin.registerFontFamily(iconLoader);
+
+data.nodes.forEach((node: IUserNode) => {
+  node.style = {
+    ...node.style,
+    icon: {
+      type: 'font',
+      fontFamily: 'graphin',
+      value: icons.user,
+    },
+  };
+});
+
+data.nodes[0].status = {
+  selected: true,
+};
+
+const lightTheme: Partial<ThemeType> = {
+  mode: 'light',
+  primaryColor: '#D77622',
+};
+
+const darkTheme: Partial<ThemeType> = {
+  mode: 'dark',
+};
+
+export default (): JSX.Element => {
+  return (
+    <div>
+      <Row>
+        <Col span={12}>
+          <Graphin data={data} layout={layout} theme={lightTheme}>
+            <ZoomCanvas disabled />
+          </Graphin>
+        </Col>
+        <Col span={12}>
+          <Graphin data={data} layout={layout} theme={darkTheme}>
+            <ZoomCanvas disabled />
+          </Graphin>
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/packages/graphin/src/index.ts
+++ b/packages/graphin/src/index.ts
@@ -1,13 +1,13 @@
 import Graphin from './Graphin';
 import GraphinContext, { GraphinContextType } from './GraphinContext';
 import Utils from './utils';
-import Layout from './layout';
 import Behaviors from './behaviors';
 import registerGraphinForce from './layout/inner/registerGraphinForce';
 import registerPresetLayout from './layout/inner/registerPresetLayout';
 import { registerGraphinCircle, registerGraphinLine } from './shape';
 /** export type */
-export { NodeStyle, EdgeStyle, GraphinData, GraphinTreeData } from './typings/type';
+export { NodeStyle, EdgeStyle, GraphinData, GraphinTreeData, IUserEdge, IUserNode, Layout } from './typings/type';
+export { ThemeType } from './theme';
 export { GraphinContextType };
 
 /** 注册 Graphin force 布局 */
@@ -26,7 +26,7 @@ const { registerFontFamily } = Graphin;
 
 /** export */
 export default Graphin;
-export { Utils, Layout, GraphinContext, Behaviors, registerFontFamily };
+export { Utils, GraphinContext, Behaviors, registerFontFamily };
 
 export {
   /** export G6 */


### PR DESCRIPTION
在业务的 Typescript 开发实践中，我们发现一些需要的 type 无法直接导出使用。因此，开此 PR 提议把以下 type 导出。

1. 导出 `IUserEdge` 和 `IUserNode` 与 `GraphinData` 一起使用
2. 导出 `ThemeType` 与 `theme` 变数一起使用
3. 导出 `Layout` 与 `layout` 变数一起使用

```tsx
import Graphin, { GraphinData, IUserNode, IUserEdge, ThemeType, Layout } from "@antv/graphin"; 

const data: GraphinData = Utils.mock(8).circle().graphin();
const theme: Partial<ThemeType> = { mode: 'light' }
const layout: Layout = { type: 'concentric' }; 

data.nodes.forEach((node: IUserNode) => console.log (node));
data.edges.forEach((edge: IUserEdge) => console.log (edge));

export default () => {
  return (
    <Graphin data={data} layout={layout} theme={theme} />
  );
};

```

## 其他事项

1. 移除了原本的 [`Layout`](https://github.com/antvis/Graphin/compare/master...CodesAreHonest:expose-necessary-types?diff=split&expand=1#diff-2a9406d2acc3648c62bf2a57b5a474502eb87f7f3e397c05c1477d4d0b002fc3L29) 不知是否会带来什么影响？ 

2. 如何在文档 (graphin-site) 里添加 typescript 的例子，是否有类似以下例子的模版或方式放入 typescript 编码 ? 

![Screenshot 2021-02-08 at 12 33 19 AM](https://user-images.githubusercontent.com/25884538/107152880-75189e00-69a5-11eb-9470-2d0bd6a3bbad.png)

