### PR TITLE
chore: 🎉  release graphin version 2.0.0-beta.15

### DIFF
--- a/packages/graphin-components/package.json
+++ b/packages/graphin-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-components",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "Components for graphin",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "react": "^16.x",
     "react-dom": "^16.x",
-    "@antv/graphin": "2.0.0-beta.14"
+    "@antv/graphin": "2.0.0-beta.15"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "@antv/g-canvas": "^0.5.1",
-    "@antv/g6": "^4.1.7",
+    "@antv/g6": "4.1.11",
     "@antv/util": "^2.0.10",
     "lodash": "^4.17.15"
   },

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -20,7 +20,6 @@
     "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.5.0",
     "@types/jest": "^25.2.3",
-    "@types/lodash": "^4.14.141",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "eventemitter3": "^4.0.0",
@@ -50,8 +49,7 @@
   "dependencies": {
     "@antv/g-canvas": "^0.5.1",
     "@antv/g6": "4.1.11",
-    "@antv/util": "^2.0.10",
-    "lodash": "^4.17.15"
+    "@antv/util": "^2.0.10"
   },
   "peerDependencies": {
     "react": "^16.x",

--- a/packages/graphin/src/Graphin.tsx
+++ b/packages/graphin/src/Graphin.tsx
@@ -1,7 +1,6 @@
 import React, { ErrorInfo } from 'react';
 // todo ,G6@unpack版本将规范类型的输出
 import G6, { Graph as IGraph, GraphOptions, GraphData, TreeGraphData } from '@antv/g6';
-import { cloneDeep } from 'lodash';
 import { deepMix } from '@antv/util';
 
 /** utils */
@@ -160,7 +159,7 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
       this.isTree = true;
     }
     console.time('clone data');
-    this.data = cloneDeep(data);
+    this.data = deepMix({}, data);
     console.timeEnd('clone data');
   };
 


### PR DESCRIPTION
- update g6 version to 4.1.11
- remove lodash dependence