### PR TITLE
chore(🆙): Upgrade React to v17.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "d3": "^6.3.1",
     "d3-selection": "^2.0.0",
     "dumi": "^1.1.0",
-    "dumi-theme-graphin": "0.1.3",
+    "dumi-theme-graphin": "file:packages/dumi-theme-graphin",
     "eslint": "^7.18.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^7.2.0",
@@ -56,7 +56,7 @@
     "lint-staged": "^10.2.2",
     "prettier": "^2.2.1",
     "react-color": "^2.19.3",
-    "react-pie-menu": "^0.2.5",
+    "react-pie-menu": "^0.3.0",
     "styled-components": "^5.2.1",
     "typescript": "^4.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "@ant-design/icons": "^4.5.0",
     "@antv/gatsby-theme-antv": "^1.0.8",
     "antd": "^4.12.3",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "@ant-design/icons": "^4.5.0",
     "@antv/gatsby-theme-antv": "^1.0.8",
     "antd": "^4.12.3",
-    "react": "^16.11.0",
-    "react-dom": "^16.11.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.5.0",
-    "@antv/gatsby-theme-antv": "^1.0.8",
+    "@antv/gatsby-theme-antv": "https://github.com/antvis/gatsby-theme-antv#upgrade-deps",
     "antd": "^4.12.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/packages/dumi-theme-graphin/package.json
+++ b/packages/dumi-theme-graphin/package.json
@@ -29,11 +29,11 @@
     "dumi": "1.1.5-0",
     "father": "^2.30.1",
     "global-dirs": "^2.1.0",
-    "react-test-renderer": "^17.0.2"
+    "react-test-renderer": "^17.0.1"
   },
   "peerDependencies": {
     "@umijs/preset-dumi": "1.x",
-    "react": "^17.0.2"
+    "react": "^17.0.1"
   },
   "license": "MIT"
 }

--- a/packages/dumi-theme-graphin/package.json
+++ b/packages/dumi-theme-graphin/package.json
@@ -29,11 +29,11 @@
     "dumi": "1.1.5-0",
     "father": "^2.30.1",
     "global-dirs": "^2.1.0",
-    "react-test-renderer": "^16.13.1"
+    "react-test-renderer": "^17.0.2"
   },
   "peerDependencies": {
     "@umijs/preset-dumi": "1.x",
-    "react": "^16.13.1"
+    "react": "^17.0.2"
   },
   "license": "MIT"
 }

--- a/packages/graphin-components/package.json
+++ b/packages/graphin-components/package.json
@@ -52,8 +52,8 @@
     "@antv/util": "^2.0.10"
   },
   "peerDependencies": {
-    "react": "^16.x",
-    "react-dom": "^16.x",
+    "react": "^17.x",
+    "react-dom": "^17.x",
     "@antv/graphin": "^2.0.0"
   },
   "publishConfig": {

--- a/packages/graphin-graphscope/package.json
+++ b/packages/graphin-graphscope/package.json
@@ -19,9 +19,9 @@
     "antd": "^4.10.3",
     "classnames": "^2.2.6",
     "re-resizable": "^6.9.0",
-    "react": "^16.9.0",
+    "react": "^17.0.2",
     "react-color": "^2.17.3",
-    "react-dom": "^16.9.0",
+    "react-dom": "^17.0.2",
     "react-draggable": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/graphin-graphscope/package.json
+++ b/packages/graphin-graphscope/package.json
@@ -19,9 +19,9 @@
     "antd": "^4.10.3",
     "classnames": "^2.2.6",
     "re-resizable": "^6.9.0",
-    "react": "^17.0.2",
+    "react": "^17.0.1",
     "react-color": "^2.17.3",
-    "react-dom": "^17.0.2",
+    "react-dom": "^17.0.1",
     "react-draggable": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/graphin-site/package.json
+++ b/packages/graphin-site/package.json
@@ -29,8 +29,8 @@
     "@antv/graphin-components": "*",
     "@antv/graphin-icons": "*",
     "antd": "^4.8.4",
-    "react": "^16.11.0",
-    "react-dom": "^16.11.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-i18next": "^11.0.1"
   }
 }

--- a/packages/graphin-site/package.json
+++ b/packages/graphin-site/package.json
@@ -29,8 +29,8 @@
     "@antv/graphin-components": "*",
     "@antv/graphin-icons": "*",
     "antd": "^4.8.4",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "react-i18next": "^11.0.1"
   }
 }

--- a/packages/graphin-studio/package.json
+++ b/packages/graphin-studio/package.json
@@ -21,9 +21,9 @@
     "copy-to-clipboard": "^3.2.0",
     "immutability-helper-x": "^1.0.5",
     "lodash": "^4.17.15",
-    "react": "^17.0.2",
+    "react": "^17.0.1",
     "react-color": "^2.17.3",
-    "react-dom": "^17.0.2",
+    "react-dom": "^17.0.1",
     "react-hot-loader": "^4.12.14",
     "react-router-dom": "^5.1.1"
   },

--- a/packages/graphin-studio/package.json
+++ b/packages/graphin-studio/package.json
@@ -21,9 +21,9 @@
     "copy-to-clipboard": "^3.2.0",
     "immutability-helper-x": "^1.0.5",
     "lodash": "^4.17.15",
-    "react": "^16.9.0",
+    "react": "^17.0.2",
     "react-color": "^2.17.3",
-    "react-dom": "^16.9.0",
+    "react-dom": "^17.0.2",
     "react-hot-loader": "^4.12.14",
     "react-router-dom": "^5.1.1"
   },

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -53,8 +53,8 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "react": "^16.x",
-    "react-dom": "^16.x"
+    "react": "^17.x",
+    "react-dom": "^17.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## About

The current stable version of React is v17.
This packages cannot use project that needs React v17 because dependency has set to React v16.
(For example, Next.js stable version 10 needs react v17)
I've rewrite all React version in `package.json` under `packages` directory.

React v16 to v17 has no breaking change, no new features.
So I think there is no critical problem to upgrade v17.
https://reactjs.org/blog/2020/10/20/react-v17.html

## Note

I cannot resolve React version dependency of the independent package `@antv/gatsby-theme-antv` .
But I've found pull request that to upgrade React to v17.
https://github.com/antvis/gatsby-theme-antv/pull/282

So This pull request force to set `@antv/gatsby-theme-antv` dependency for `upgrade-deps` branch.
It should be fixed before merge.
So this pull request cannot merge until https://github.com/antvis/gatsby-theme-antv/pull/282 has merged.
I want to merge https://github.com/antvis/gatsby-theme-antv/pull/282 ASAP
