### PR TITLE
docs: fix link of README-zh.CN.md in README

### DIFF
--- a/packages/graphin/README.md
+++ b/packages/graphin/README.md
@@ -6,7 +6,7 @@
 
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/antvis/graphin.svg)](http://isitmaintained.com/project/antvis/graphin 'Percentage of issues still open')
 
-[中文](./README-cn.ZH.md)
+[中文](./README-zh.CN.md)
 
 ## @antv/graphin
 


### PR DESCRIPTION
This PR fixes the link of `README-zh.CN.md` in `README`.