### PR TITLE
chore: release graphin 2.2.0 

### DIFF
--- a/packages/graphin-components/package.json
+++ b/packages/graphin-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-components",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Components for graphin",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/graphin-components/src/CreateEdge/index.tsx
+++ b/packages/graphin-components/src/CreateEdge/index.tsx
@@ -47,9 +47,11 @@ const CreateEdge: React.FunctionComponent<Props> = props => {
 
     graph.on('aftercreateedge', handleAftercreateedge);
     return () => {
-      graph.removeBehaviors('create-edge', 'default');
-      graph.get('canvas').setCursor('default');
-      graph.off('aftercreateedge', handleAftercreateedge);
+      if (graph && !graph.destroyed) {
+        graph.removeBehaviors('create-edge', 'default');
+        graph.get('canvas').setCursor('default');
+        graph.off('aftercreateedge', handleAftercreateedge);
+      }
     };
   }, [active, graph, onChange]);
 

--- a/packages/graphin-components/src/FishEye/index.tsx
+++ b/packages/graphin-components/src/FishEye/index.tsx
@@ -1,6 +1,6 @@
+/* eslint-disable no-undef */
+import { G6, GraphinContext } from '@antv/graphin';
 import React from 'react';
-
-import { GraphinContext, G6 } from '@antv/graphin';
 
 const defaultOptions = {
   r: 249,
@@ -37,7 +37,7 @@ export interface FishEyeProps {
   handleEscListener?: () => void;
 }
 
-const FishEye: React.FunctionComponent<FishEyeProps> = (props) => {
+const FishEye: React.FunctionComponent<FishEyeProps> = props => {
   const { graph } = React.useContext(GraphinContext);
   const { options, visible, handleEscListener } = props;
 
@@ -50,17 +50,17 @@ const FishEye: React.FunctionComponent<FishEyeProps> = (props) => {
     if (FishEyeOptions.showLabel) {
       // 先将图上的label全部隐藏
 
-      graph.getNodes().forEach((node) => {
+      graph.getNodes().forEach(node => {
         node
           .getContainer()
           .getChildren()
-          .forEach((shape) => {
+          .forEach(shape => {
             if (shape.get('type') === 'text') shape.hide();
           });
       });
     }
     const fishEye = new G6.Fisheye(FishEyeOptions);
-    const escListener = (e) => {
+    const escListener = e => {
       if (e.keyCode === 27) {
         if (handleEscListener) {
           handleEscListener();
@@ -78,13 +78,15 @@ const FishEye: React.FunctionComponent<FishEyeProps> = (props) => {
       window.addEventListener('keydown', escListener);
     }
     return () => {
-      graph.get('canvas').setCursor('default');
-      graph.removePlugin(fishEye);
+      if (graph && !graph.destroyed) {
+        graph.get('canvas').setCursor('default');
+        graph.removePlugin(fishEye);
+      }
       if (handleEscListener) {
         window.removeEventListener('keydown', escListener);
       }
     };
-  }, [options, visible, handleEscListener]);
+  }, [graph, options, visible, handleEscListener]);
 
   return null;
 };

--- a/packages/graphin-components/src/Grid/index.tsx
+++ b/packages/graphin-components/src/Grid/index.tsx
@@ -1,5 +1,5 @@
+import { G6, GraphinContext } from '@antv/graphin';
 import React from 'react';
-import { GraphinContext, G6 } from '@antv/graphin';
 import './index.less';
 
 export interface GridProps {
@@ -11,19 +11,18 @@ export interface GridProps {
 
 const Grid: React.FunctionComponent<GridProps> = ({ img }) => {
   const { graph } = React.useContext(GraphinContext);
-  let grid;
 
   React.useEffect(() => {
-    grid = new G6.Grid({ img });
-    graph?.addPlugin(grid);
+    const grid = new G6.Grid({ img });
+    graph.addPlugin(grid);
     return () => {
-      if (grid) {
-        graph?.removePlugin(grid);
+      if (graph && !graph.destroy) {
+        graph.removePlugin(grid);
       }
     };
   }, [img, graph]);
 
-  return <></>;
+  return null;
 };
 
 export default Grid;

--- a/packages/graphin-components/src/MiniMap/index.tsx
+++ b/packages/graphin-components/src/MiniMap/index.tsx
@@ -1,6 +1,5 @@
+import { G6, GraphinContext } from '@antv/graphin';
 import React from 'react';
-
-import { GraphinContext, G6 } from '@antv/graphin';
 
 const defaultOptions = {
   className: 'graphin-minimap',
@@ -66,7 +65,9 @@ const MiniMap: React.FunctionComponent<MiniMapProps> = props => {
     graph.addPlugin(miniMap);
 
     return () => {
-      graph.removePlugin(miniMap);
+      if (miniMap && !miniMap.destroy) {
+        graph.removePlugin(miniMap);
+      }
     };
   }, [options]);
 

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "the react toolkit for graph analysis based on g6",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -20,7 +20,7 @@
     "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.5.0",
     "@types/jest": "^25.2.3",
-    "@types/lodash-es":"latest",
+    "@types/lodash-es": "latest",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "eventemitter3": "^4.0.0",

--- a/packages/graphin/src/Graphin.tsx
+++ b/packages/graphin/src/Graphin.tsx
@@ -1,30 +1,24 @@
-import React, { ErrorInfo } from 'react';
 // todo ,G6@unpack版本将规范类型的输出
-import G6, { Graph as IGraph, GraphOptions, GraphData, TreeGraphData } from '@antv/g6';
-import { deepMix } from '@antv/util';
-/** utils */
-// import shallowEqual from './utils/shallowEqual';
-import deepEqual from './utils/deepEqual';
-
+import G6, { Graph as IGraph, GraphData, GraphOptions, TreeGraphData } from '@antv/g6';
 import cloneDeep from 'lodash-es/cloneDeep';
-
-import './index.less';
-
-/** Context */
-import GraphinContext from './GraphinContext';
-/** 内置 Behaviors */
-import Behaviors from './behaviors';
-/** 内置布局 */
-import LayoutController from './layout';
+import React, { ErrorInfo } from 'react';
 /** 内置API */
 import ApiController from './apis';
 import { ApisType } from './apis/types';
-
-/** types  */
-import { GraphinProps, IconLoader, GraphinData, GraphinTreeData } from './typings/type';
-import { TREE_LAYOUTS, DEFAULT_TREE_LATOUT_OPTIONS } from './consts';
-
+/** 内置 Behaviors */
+import Behaviors from './behaviors';
+import { DEFAULT_TREE_LATOUT_OPTIONS, TREE_LAYOUTS } from './consts';
+/** Context */
+import GraphinContext from './GraphinContext';
+import './index.less';
+/** 内置布局 */
+import LayoutController from './layout';
 import { getDefaultStyleByTheme, ThemeData } from './theme/index';
+/** types  */
+import { GraphinData, GraphinProps, GraphinTreeData, IconLoader } from './typings/type';
+/** utils */
+// import shallowEqual from './utils/shallowEqual';
+import deepEqual from './utils/deepEqual';
 
 const { DragCanvas, ZoomCanvas, DragNode, DragCombo, ClickSelect, BrushSelect, ResizeCanvas, Hoverable } = Behaviors;
 
@@ -170,9 +164,9 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
       layout,
       width,
       height,
-      defaultCombo,
-      defaultEdge,
-      defaultNode,
+      defaultCombo = { style: {}, type: 'graphin-combo' },
+      defaultEdge = { style: {}, type: 'graphin-line' },
+      defaultNode = { style: {}, type: 'graphin-circle' },
       nodeStateStyles,
       edgeStateStyles,
       comboStateStyles,
@@ -209,17 +203,15 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
     /** graph type */
     this.isTree =
       Boolean((data as GraphinTreeData).children) || TREE_LAYOUTS.indexOf(String(layout && layout.type)) !== -1;
-    const isGraphinNodeType = defaultNode?.type === undefined || defaultNode?.type === defaultNodeStyle.type;
-    const isGraphinEdgeType = defaultEdge?.type === undefined || defaultEdge?.type === defaultEdgeStyle.type;
 
     const finalStyle = {
-      defaultNode: isGraphinNodeType ? deepMix({}, defaultNodeStyle, defaultNode) : defaultNode,
-      defaultEdge: isGraphinEdgeType ? deepMix({}, defaultEdgeStyle, defaultEdge) : defaultEdge,
-      defaultCombo: deepMix({}, defaultComboStyle, defaultCombo), // TODO:COMBO的样式需要内部自定义
+      defaultNode: { style: { ...defaultNode.style, _theme: theme }, type: defaultNode.type || 'graphin-circle' }, // isGraphinNodeType ? deepMix({}, defaultNodeStyle, defaultNode) : defaultNode,
+      defaultEdge: { style: { ...defaultEdge.style, _theme: theme }, type: defaultEdge.type || 'graphin-line' }, // isGraphinEdgeType ? deepMix({}, defaultEdgeStyle, defaultEdge) : defaultEdge,
+      defaultCombo: { style: { ...defaultCombo.style, _theme: theme }, type: defaultCombo.type || 'combo' }, // deepMix({}, defaultComboStyle, defaultCombo), // TODO:COMBO的样式需要内部自定义
       /** status 样式 */
-      nodeStateStyles: isGraphinNodeType ? deepMix({}, defaultNodeStatusStyle, nodeStateStyles) : nodeStateStyles,
-      edgeStateStyles: isGraphinEdgeType ? deepMix({}, defaultEdgeStatusStyle, edgeStateStyles) : edgeStateStyles,
-      comboStateStyles: deepMix({}, defaultComboStatusStyle, comboStateStyles),
+      nodeStateStyles, // isGraphinNodeType ? deepMix({}, defaultNodeStatusStyle, nodeStateStyles) : nodeStateStyles,
+      edgeStateStyles, // isGraphinEdgeType ? deepMix({}, defaultEdgeStatusStyle, edgeStateStyles) : edgeStateStyles,
+      comboStateStyles, // deepMix({}, defaultComboStatusStyle, comboStateStyles),
     };
     // @ts-ignore
     this.theme = { ...finalStyle, ...otherTheme } as ThemeData;
@@ -231,7 +223,6 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
       height: this.height,
       animate: animate !== false,
       ...finalStyle,
-
       modes,
       ...otherOptions,
     } as GraphOptions;

--- a/packages/graphin/src/theme/index.ts
+++ b/packages/graphin/src/theme/index.ts
@@ -1,7 +1,7 @@
-import getNodeStyleByTheme from './node-style';
-import getEdgeStyleByTheme from './edge-style';
+import { ComboStyle, EdgeStyle, NodeStyle } from '../typings/type';
 import getComboStyleByTheme from './combo-style';
-import { NodeStyle, EdgeStyle, ComboStyle } from '../typings/type';
+import getEdgeStyleByTheme from './edge-style';
+import getNodeStyleByTheme from './node-style';
 
 export const DEFAULT_THEME = {
   mode: 'light',


### PR DESCRIPTION
- 修复组件卸载报错
- 新增Grid组件
- 移除 defaultNodeStyle 设置，仅传递 theme 数值，默认样式计算放在节点和边的注册流程中。