### PR TITLE
fix: minimap not unmounting due typo

### DIFF
--- a/packages/graphin-components/src/MiniMap/index.tsx
+++ b/packages/graphin-components/src/MiniMap/index.tsx
@@ -65,7 +65,7 @@ const MiniMap: React.FunctionComponent<MiniMapProps> = props => {
     graph.addPlugin(miniMap);
 
     return () => {
-      if (miniMap && !miniMap.destroy) {
+      if (miniMap && !miniMap.destroyed) {
         graph.removePlugin(miniMap);
       }
     };


### PR DESCRIPTION
Ths commit fixes issue with unmounting minimap component.

The issue is caused by typo where "destroy" is used instead of "destroyed". The former is a method, and this results the unreachable code forever.