### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/dumi-theme-graphin/package.json
+++ b/packages/dumi-theme-graphin/package.json
@@ -24,6 +24,11 @@
     "react-slick": "^0.28.0",
     "react-use": "^17.1.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/Graphin.git",
+    "directory": "packages/dumi-theme-graphin"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.3",
     "@testing-library/react": "^10.4.8",

--- a/packages/graphin-components/package.json
+++ b/packages/graphin-components/package.json
@@ -12,6 +12,11 @@
     "test": "jest",
     "clean": "rimraf es esm lib dist"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/Graphin.git",
+    "directory": "packages/graphin-components"
+  },
   "author": "",
   "license": "MIT",
   "sideEffects": [

--- a/packages/graphin-graphscope/package.json
+++ b/packages/graphin-graphscope/package.json
@@ -24,6 +24,11 @@
     "react-dom": "^17.0.1",
     "react-draggable": "^4.4.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/Graphin.git",
+    "directory": "packages/graphin-graphscope"
+  },
   "devDependencies": {
     "@ant-design/icons": "^4.3.0",
     "@babel/cli": "^7.6.2",

--- a/packages/graphin-icons/package.json
+++ b/packages/graphin-icons/package.json
@@ -11,6 +11,11 @@
   "sideEffects": [
     "*.css"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/Graphin.git",
+    "directory": "packages/graphin-icons"
+  },
   "author": "",
   "license": "ISC",
   "publishConfig": {

--- a/packages/graphin-studio/package.json
+++ b/packages/graphin-studio/package.json
@@ -27,6 +27,11 @@
     "react-hot-loader": "^4.12.14",
     "react-router-dom": "^5.1.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/Graphin.git",
+    "directory": "packages/graphin-studio"
+  },
   "devDependencies": {
     "@babel/cli": "^7.6.2",
     "@babel/core": "^7.6.2",

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -13,6 +13,11 @@
     "prettier": "prettier --write ./src/**/**/**/*.js",
     "clean": "rimraf es esm lib dist"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/Graphin.git",
+    "directory": "packages/graphin"
+  },
   "devDependencies": {
     "@antv/g-base": "^0.5.5",
     "@antv/hierarchy": "^0.6.6",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @antv/graphin
* dumi-theme-graphin
* @antv/graphin-components
* @antv/graphin-graphscope
* @antv/graphin-icons
* @antv/graphin-studio