### PR TITLE
fix: badge with text

### DIFF
--- a/packages/graphin/src/shape/graphin-circle.ts
+++ b/packages/graphin/src/shape/graphin-circle.ts
@@ -220,13 +220,15 @@ const drawBadge = (badge: any, group: IGroup, r: number) => {
   // 绘制 badge 的外层容器，根据宽度和高度确定是 circle 还是 rect
 
   if (width === height) {
+    realX += offset[0];
+    realY += offset[1];
     group.addShape('circle', {
       attrs: {
         r: width / 2 + padding,
         fill,
         stroke,
-        x: realX + offset[0],
-        y: realY + offset[1],
+        x: realX,
+        y: realY,
       },
       name: 'badges-circle',
     });


### PR DESCRIPTION
Close https://github.com/antvis/Graphin/issues/271

The offset was not handled correctly for the text on a circular badge

Before:
![image](https://user-images.githubusercontent.com/2861371/138890502-03a36ef9-773f-4e2e-ae79-ae15954807f4.png)
After:
![image](https://user-images.githubusercontent.com/2861371/138890524-db729f03-5ae3-4203-a2a2-2b936ed68d2e.png)
