### PR TITLE
fix: Update positions at the end of gforce layout

### DIFF
--- a/packages/graphin/src/layout/index.ts
+++ b/packages/graphin/src/layout/index.ts
@@ -168,13 +168,16 @@ class LayoutController {
         if (onTick) {
           onTick();
         }
-
-        graph.refreshPositions();
       };
 
       this.options.tick = tick;
       const { onLayoutEnd } = this.options;
       this.options.onLayoutEnd = () => {
+        if (graph.get('animate')) {
+          graph.positionsAnimate();
+        } else {
+          graph.refreshPositions();
+        }
         if (onLayoutEnd) {
           onLayoutEnd();
         }


### PR DESCRIPTION
### Description

Prevent gforce layout from jittering by updating the nodes on every tick. Update the node positions at the end of layout.

Fixes #295 

<table>
<tr>
<td>

Before

https://user-images.githubusercontent.com/7285903/143027902-d929ebd0-ee1a-40c9-b27f-dce5793550fa.mp4

</td>
<td>

After

https://user-images.githubusercontent.com/7285903/143027891-89c0db83-b7c7-4d2b-80d5-3ac97d28ff72.mp4

</td>
</tr>
</table>

