### PR TITLE
Feat: support animation in ZoomCanvas behavior

### DIFF
--- a/packages/graphin/src/behaviors/ZoomCanvas.tsx
+++ b/packages/graphin/src/behaviors/ZoomCanvas.tsx
@@ -25,6 +25,10 @@ const defaultConfig = {
   },
   /** 是否禁用该功能 */
   disabled: false,
+  animate: false,
+  animateCfg: {
+    duration: 500,
+  },
 };
 
 export type IDragCanvasProps = Partial<typeof defaultConfig>;

--- a/packages/graphin/src/typings/type.ts
+++ b/packages/graphin/src/typings/type.ts
@@ -270,7 +270,7 @@ export interface EdgeStyle {
         /**
          *  @description 透明度，默认值为 1；
          */
-        opacity: number;
+        opacity?: number;
       };
     } & CommondAttrsStyle
   >;


### PR DESCRIPTION
Recently I added the animation support for zoom operations in G6, this is the last bit :)

Additionally, this makes the opacity parameter optional (I overlooked that in my previous PR)