### PR TITLE
fix: straight line on even count poly edges

### DIFF
--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -55,6 +55,7 @@
   "author": "AntV",
   "license": "MIT",
   "dependencies": {
+    "@antv/g6": "^4.5.3",
     "@antv/util": "^2.0.10",
     "@types/lodash.clonedeep": "^4.5.6",
     "d3-quadtree": "^3.0.1",

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -55,7 +55,6 @@
   "author": "AntV",
   "license": "MIT",
   "dependencies": {
-    "@antv/g6": "^4.5.3",
     "@antv/util": "^2.0.10",
     "@types/lodash.clonedeep": "^4.5.6",
     "d3-quadtree": "^3.0.1",

--- a/packages/graphin/src/utils/processEdges.ts
+++ b/packages/graphin/src/utils/processEdges.ts
@@ -60,7 +60,7 @@ const processEdges = (
         let distance;
         if (isEvenCount) {
           // 奇数
-          const idx = Math.ceil(index / 2);
+          const idx = Math.ceil((index + 1) / 2);
           distance = poly * idx;
         } else {
           // 偶数


### PR DESCRIPTION
Using the `Utils.processEdges` function to process poly edges with an even count causes at least one of the edges to be a straight line as opposed to a curved edge. This PR fixes that. Below are some screenshots of the issue and its fix.

Before (with 2 edges)
<img width="456" alt="With 2 Even Edges" src="https://user-images.githubusercontent.com/83455275/151018770-00572a70-d5ad-4317-80c6-60dad213dcf3.png">

After (with 2 edges)
<img width="421" alt="Fix - with 2 even edges" src="https://user-images.githubusercontent.com/83455275/151018833-608feb74-f66f-405c-85e9-08446c44eeed.png">

Before (with 4 edges)
<img width="436" alt="With 4 even edges" src="https://user-images.githubusercontent.com/83455275/151018881-a100d489-93d8-499e-ac4c-72e1679bf708.png">

After (with 4 edges)
<img width="435" alt="Fix - with 4 even edges" src="https://user-images.githubusercontent.com/83455275/151018939-f298b18a-29b5-4170-a0a5-de2ae0c206ed.png">

