### PR TITLE
fix: Fix multiple `afterlayout` emits

### DIFF
--- a/packages/graphin/src/layout/index.ts
+++ b/packages/graphin/src/layout/index.ts
@@ -79,9 +79,13 @@ class LayoutController {
   start() {
     const { type } = this.options;
     this.instance.execute();
-    if (!(type === 'force' || type === 'g6force' || type === 'gForce' || type === 'comboCombined')) {
-      this.refreshPosition();
+
+    if ((type === 'force' || type === 'g6force' || type === 'gForce' || type === 'comboCombined')) {
+      // We emit afterlayout on options.layoutEnd()
+      return;
     }
+
+    this.refreshPosition();
     this.graph.emit('afterlayout');
   }
 


### PR DESCRIPTION
### Description

Since `graph.emit('afterlayout')` is being used [on layout end ](https://github.com/antvis/Graphin/blob/8e0fe869ce4dd5814ff51f9a58ed8d634be7adb7/packages/graphin/src/layout/index.ts#L190) for force layouts. It causes multiple emits.

### Before

<img width="396" alt="Screenshot 2022-03-16 at 6 00 05 PM" src="https://user-images.githubusercontent.com/7285903/158658957-5ede1c0d-efc4-4c39-a12e-f3eb56201e4a.png">

### After

<img width="465" alt="Screenshot 2022-03-16 at 6 01 21 PM" src="https://user-images.githubusercontent.com/7285903/158658964-f45ad0e4-7dac-469c-985d-cb85d1fd41d3.png">
