### PR TITLE
feat: Made the tooltip component optionally hoverable.

### DIFF
--- a/packages/graphin-components/src/Tooltip/Edge.tsx
+++ b/packages/graphin-components/src/Tooltip/Edge.tsx
@@ -8,7 +8,7 @@ export interface EdgeProps {
    * @description children 为一个函数
    * @type (model: any) => JSX.Element | JSX.Element[];
    */
-  children: (model: any) => JSX.Element | JSX.Element[];
+  children: (model: any) => JSX.Element | JSX.Element[] | null;
 }
 
 const Edge: React.FunctionComponent<EdgeProps> = (props) => {
@@ -20,7 +20,13 @@ const Edge: React.FunctionComponent<EdgeProps> = (props) => {
     console.error('<Tooltip.Edge /> children should be a function');
     return null;
   }
-  return <div className="graphin-components-tooltip-content">{children(item.getModel())}</div>;
+
+  const element = children(item.getModel());
+  if (element === null) {
+    return null;
+  }
+
+  return <div className="graphin-components-tooltip-content">{element}</div>;
 };
 
 export default Edge;

--- a/packages/graphin-components/src/Tooltip/Node.tsx
+++ b/packages/graphin-components/src/Tooltip/Node.tsx
@@ -8,7 +8,7 @@ export interface NodeProps {
    * @description children 为一个函数
    * @type (model: any) => JSX.Element | JSX.Element[];
    */
-  children: (model: any) => JSX.Element | JSX.Element[];
+  children: (model: any) => JSX.Element | JSX.Element[] | null;
 }
 
 const Node: React.FunctionComponent<NodeProps> = props => {
@@ -16,11 +16,20 @@ const Node: React.FunctionComponent<NodeProps> = props => {
   const { tooltip } = React.useContext(GraphinContext);
   const context = tooltip.node;
   const { item } = context;
+  if (children === null) {
+    return null;
+  }
   if (typeof children !== 'function') {
     console.error('<Tooltip.Node /> children should be a function');
     return null;
   }
-  return <div className="graphin-components-tooltip-content">{children(item.getModel())}</div>;
+
+  const element = children(item.getModel());
+  if (element === null) {
+    return null;
+  }
+
+  return <div className="graphin-components-tooltip-content">{element}</div>;
 };
 
 export default Node;

--- a/packages/graphin-components/src/Tooltip/Node.tsx
+++ b/packages/graphin-components/src/Tooltip/Node.tsx
@@ -16,9 +16,6 @@ const Node: React.FunctionComponent<NodeProps> = props => {
   const { tooltip } = React.useContext(GraphinContext);
   const context = tooltip.node;
   const { item } = context;
-  if (children === null) {
-    return null;
-  }
   if (typeof children !== 'function') {
     console.error('<Tooltip.Node /> children should be a function');
     return null;

--- a/packages/graphin-components/src/Tooltip/index.tsx
+++ b/packages/graphin-components/src/Tooltip/index.tsx
@@ -32,6 +32,10 @@ interface TooltipProps {
    * @description.en-US display arrow
    */
   hasArrow?: boolean;
+  /**
+  * @description Tooltip hoverable
+  */
+  hoverable?: boolean;
 }
 
 interface State {
@@ -157,7 +161,7 @@ const getTranslate = ({
 // let containerRef: HTMLDivElement | null;
 
 const Tooltip: React.FunctionComponent<TooltipProps> & { Node: typeof Node } & { Edge: typeof Edge } = props => {
-  const { children, bindType = 'node', style, placement = 'top', hasArrow } = props;
+  const { children, bindType = 'node', style, placement = 'top', hasArrow, hoverable } = props;
   const graphin = React.useContext(GraphinContext);
   const { graph } = graphin;
 
@@ -199,8 +203,17 @@ const Tooltip: React.FunctionComponent<TooltipProps> & { Node: typeof Node } & {
       };
     });
   };
-  const handleClose = () => {
-    setState(preState => {
+  const handleClose = (e: any): void => {
+    const canvas = graph.get('canvas');
+    const { x, y } = canvas.getPointByEvent(e);
+    const shape = canvas.getShape(x, y, e);
+    const parentId = shape?.get('parent')?.get('id');
+    const itemId = item?.getID();
+
+    const inTooltip = document.querySelector('.graphin-components-tooltip:hover');
+    const inShape = parentId && (parentId === itemId);
+
+    !(hoverable && (inTooltip || inShape)) && setState(preState => {
       return {
         ...preState,
         visible: false,
@@ -303,7 +316,7 @@ const Tooltip: React.FunctionComponent<TooltipProps> & { Node: typeof Node } & {
         style={{ ...defaultStyle, ...style, ...positionStyle }}
       >
         {visible && (
-          <div>
+          <div onMouseLeave={hoverable ? e => visible && handleClose(e) : undefined}>
             {hasArrow && <div className={`tooltip-arrow ${placement}`} />}
             {children}
           </div>

--- a/packages/graphin-components/src/Tooltip/index.tsx
+++ b/packages/graphin-components/src/Tooltip/index.tsx
@@ -160,6 +160,8 @@ const getTranslate = ({
 };
 // let containerRef: HTMLDivElement | null;
 
+const tooltipClassName = 'graphin-components-tooltip';
+
 const Tooltip: React.FunctionComponent<TooltipProps> & { Node: typeof Node } & { Edge: typeof Edge } = props => {
   const { children, bindType = 'node', style, placement = 'top', hasArrow, hoverable } = props;
   const graphin = React.useContext(GraphinContext);
@@ -204,16 +206,20 @@ const Tooltip: React.FunctionComponent<TooltipProps> & { Node: typeof Node } & {
     });
   };
   const handleClose = (e: any): void => {
-    const canvas = graph.get('canvas');
-    const { x, y } = canvas.getPointByEvent(e);
-    const shape = canvas.getShape(x, y, e);
-    const parentId = shape?.get('parent')?.get('id');
-    const itemId = item?.getID();
+    let keepOpen = false;
+    if (hoverable) {
+      const canvas = graph.get('canvas');
+      const { x, y } = canvas.getPointByEvent(e);
+      const shape = canvas.getShape(x, y, e);
+      const parentId = shape?.get('parent')?.get('id');
+      const itemId = item?.getID();
+      
+      const inShape = parentId && (parentId === itemId);
+      const inTooltip = document.querySelector(`.${tooltipClassName}:hover`);
+      keepOpen = !!(inShape || inTooltip);
+    }
 
-    const inTooltip = document.querySelector('.graphin-components-tooltip:hover');
-    const inShape = parentId && (parentId === itemId);
-
-    !(hoverable && (inTooltip || inShape)) && setState(preState => {
+    !keepOpen && setState(preState => {
       return {
         ...preState,
         visible: false,
@@ -311,7 +317,7 @@ const Tooltip: React.FunctionComponent<TooltipProps> & { Node: typeof Node } & {
         ref={() => {
           // containerRef = node;
         }}
-        className={`graphin-components-tooltip ${placement}`}
+        className={`${tooltipClassName} ${placement}`}
         // @ts-ignore
         style={{ ...defaultStyle, ...style, ...positionStyle }}
       >


### PR DESCRIPTION
This PR introduces hoverability for the tooltip component and a flag to switch between the hoverable and original behaviours.
Making the tooltip hoverable, and thus interactable, allows displaying scrollable or interactable content in it.
Another minor change introduced in this PR makes so the tooltip will not render if `null` is passed as content, which is useful when not all nodes have content that needs to be shown.