### PR TITLE
fix: Update broken demo since v2.3.3

### DIFF
--- a/packages/graphin/docs/render/element/demos/node-animate.tsx
+++ b/packages/graphin/docs/render/element/demos/node-animate.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Graphin, { Utils, Behaviors } from '@antv/graphin';
 
-const { ZoomCanvas } = Behaviors;
+const { ZoomCanvas, Hoverable } = Behaviors;
 
 const data = Utils.mock(10).circle().graphin();
 const layout = {
@@ -48,6 +48,7 @@ export default () => {
     <div>
       <Graphin data={data} layout={layout} defaultNode={defaultNode} nodeStateStyles={defaultNodeStatusStyle}>
         <ZoomCanvas />
+        <Hoverable bindType="node" />
       </Graphin>
     </div>
   );


### PR DESCRIPTION
Changes to be committed:
	modified:   packages/graphin/docs/render/element/demos/node-animate.tsx

This PR contains a simple fix to update a hoverable demo that was broken since v2.3.3 which removes the default "hoverable" behavior. 