### PR TITLE
fix: Fix processEdges issue

### DIFF
--- a/packages/graphin/src/utils/processEdges.ts
+++ b/packages/graphin/src/utils/processEdges.ts
@@ -103,6 +103,7 @@ const processEdges = (
         newEdges.push(edge);
       });
     } else {
+      // reset keyshape type
       (0, Utils.deepMix)(edges[0], {
         style: {
           keyshape: {

--- a/packages/graphin/src/utils/processEdges.ts
+++ b/packages/graphin/src/utils/processEdges.ts
@@ -103,6 +103,13 @@ const processEdges = (
         newEdges.push(edge);
       });
     } else {
+      (0, Utils.deepMix)(edges[0], {
+        style: {
+          keyshape: {
+            type: 'line'
+          }
+        }
+      })
       newEdges.push(edges[0]);
     }
   });


### PR DESCRIPTION
fix processEdges didn't process the keyshape of an edge used to be a poly one after other edges removed from the same source/target
set keyshape type back to line when there's only 1 edge

before:
![image](https://user-images.githubusercontent.com/4090171/160079751-01365026-228e-4a1e-97b0-551c582d5412.png)

 after:
![image](https://user-images.githubusercontent.com/4090171/160079931-9c1746f8-e42b-4ba6-8163-3b1b6810e6cd.png)
