### PR TITLE
移除移除layout对react的依赖

### DIFF
--- a/packages/graphin/src/layout/inner/registerGraphinForce.ts
+++ b/packages/graphin/src/layout/inner/registerGraphinForce.ts
@@ -1,9 +1,9 @@
 import Force from '../force';
-import Graphin from '../../Graphin';
+import G6 from '@antv/g6';
 import { GraphinData } from '../../typings/type';
 
 export default () => {
-  Graphin.registerLayout('graphin-force', {
+  G6.registerLayout('graphin-force', {
     /**
      * 定义自定义行为的默认参数，会与用户传入的参数进行合并
      */

--- a/packages/graphin/src/layout/inner/registerPresetLayout.ts
+++ b/packages/graphin/src/layout/inner/registerPresetLayout.ts
@@ -1,7 +1,7 @@
-import Graphin from '../../Graphin';
+import G6 from '@antv/g6';
 
 export default () => {
-  Graphin.registerLayout('preset', {
+  G6.registerLayout('preset', {
     init() {},
     execute() {},
     destroy() {


### PR DESCRIPTION
移除layout对react的依赖后，可以在vue或者其他框架中直接使用graphin-force和preset的layout