### PR TITLE
feat: 使用一个独立的ContextMenuContext在ContextMenu中传递方法和数据

### DIFF
--- a/packages/graphin-components/src/ContextMenu/Context.tsx
+++ b/packages/graphin-components/src/ContextMenu/Context.tsx
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+
+const defaultContext = {
+  visible: false,
+  x: 0,
+  y: 0,
+  bindType: 'node',
+};
+export interface IG6GraphEvent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+export interface ContextMenuContextType {
+  /** 当前状态 */
+  visible: boolean;
+  x: number;
+  y: number;
+  /** 触发的元素 */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item?: IG6GraphEvent['item'];
+  bindType: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+// @ts-ignore
+const ContextMenuContext: React.Context<ContextMenuContextType> = React.createContext(defaultContext as ContextMenuContextType);
+
+export default ContextMenuContext;
+

--- a/packages/graphin-components/src/ContextMenu/Menu.tsx
+++ b/packages/graphin-components/src/ContextMenu/Menu.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { GraphinContext } from '@antv/graphin';
 import React from 'react';
+import ContextMenuContext from './Context'
 import './index.less';
 
 export interface MenuProps {
@@ -34,20 +34,10 @@ export interface Item {
 }
 const Item = props => {
   const { children, onClick = () => {} } = props;
-  const graphin = React.useContext(GraphinContext);
-  const handleClose = () => {
-    onClick();
-    const { contextmenu } = graphin;
-    // 临时方案
-    if (contextmenu.node) {
-      contextmenu.node.handleClose();
-    }
-    if (contextmenu.edge) {
-      contextmenu.edge.handleClose();
-    }
-    if (contextmenu.canvas) {
-      contextmenu.canvas.handleClose();
-    }
+  const { item, handleClose: close } = React.useContext(ContextMenuContext);
+  const handleClose = (e) => {
+    onClick(e, item ? item.getModel() : undefined);
+    close && close(); // 关闭菜单
   };
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events
   // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
@@ -57,32 +47,12 @@ const Item = props => {
 const Menu: React.FunctionComponent<MenuProps> & {
   Item: typeof Item;
 } = props => {
-  const { bindType = 'node' } = props;
-  const graphin = React.useContext(GraphinContext);
-
-  const { options, onChange } = props;
+  const { bindType = 'node', options, onChange = () => {} } = props;
+  const { item, handleClose: close } = React.useContext(ContextMenuContext);
 
   const handleClick = e => {
-    try {
-      const { contextmenu } = graphin;
-
-      let item = null;
-      if (bindType === 'node') {
-        item = contextmenu.node.item.getModel();
-      }
-      if (bindType === 'edge') {
-        item = contextmenu.edge.item.getModel();
-      }
-      if (bindType === 'canvas') {
-        item = null;
-      }
-      if (onChange) {
-        onChange(e, item);
-        contextmenu[bindType].handleClose();
-      }
-    } catch (error) {
-      console.log(error);
-    }
+    onChange(e, item ? item.getModel() : undefined);
+    close && close(); // 关闭菜单
   };
 
   const { children } = props;

--- a/packages/graphin-components/src/ContextMenu/index.tsx
+++ b/packages/graphin-components/src/ContextMenu/index.tsx
@@ -1,15 +1,10 @@
 import * as Graphin from '@antv/graphin';
 import React, { useEffect } from 'react';
 import Menu from './Menu';
+import ContextMenuContext, { ContextMenuContextType, IG6GraphEvent } from './Context'
 
 const { GraphinContext } = Graphin;
 
-interface IG6GraphEvent {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  item: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
 const defaultStyle: React.CSSProperties = {
   width: 200,
   background: '#fff',
@@ -38,12 +33,6 @@ const ContextMenu: React.FunctionComponent<ContextMenuProps> & { Menu: typeof Me
   const graphin = React.useContext(GraphinContext);
   const { graph } = graphin;
 
-  const [state, setState] = React.useState<State>({
-    visible: false,
-    x: 0,
-    y: 0,
-    item: null,
-  });
   const handleShow = (e: IG6GraphEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -108,6 +97,16 @@ const ContextMenu: React.FunctionComponent<ContextMenuProps> & { Menu: typeof Me
     });
   };
 
+  const [state, setState] = React.useState<ContextMenuContextType>({
+    handleOpen: handleShow,
+    handleClose,
+    visible: false,
+    x: 0,
+    y: 0,
+    item: null,
+    bindType,
+  });
+
   useEffect(() => {
     // @ts-ignore
     graph.on(`${bindType}:contextmenu`, handleShow);
@@ -130,24 +129,10 @@ const ContextMenu: React.FunctionComponent<ContextMenuProps> & { Menu: typeof Me
     top: y,
   };
 
-  /** 将一些方法和数据传递给子组件 */
-  graphin.contextmenu = {
-    ...graphin.contextmenu,
-    [bindType]: {
-      handleOpen: handleShow,
-      handleClose,
-      item,
-      visible,
-      x,
-      y,
-      bindType,
-    },
-  };
-
   const id = (item && !item.destroyed && item.getModel && item.getModel().id) || '';
 
   return (
-    <>
+    <ContextMenuContext.Provider value={state}>
       <div
         ref={node => {
           containerRef = node;
@@ -159,7 +144,7 @@ const ContextMenu: React.FunctionComponent<ContextMenuProps> & { Menu: typeof Me
       >
         {visible && children}
       </div>
-    </>
+    </ContextMenuContext.Provider>
   );
 };
 


### PR DESCRIPTION
1. 这样可以不用以一种比较奇怪的方式去更新GraphinContext中的contextmenu字段
2. 每一个ContextMenu共享自己的一份数据，不至于更新数据的时候出错
