### PR TITLE
fix: 更新图数据后，Hull组件updateData报错

### DIFF
--- a/packages/graphin/src/components/Hull/index.tsx
+++ b/packages/graphin/src/components/Hull/index.tsx
@@ -115,7 +115,7 @@ const Hull: React.FunctionComponent<IHullProps> = props => {
         // 直接调用updateData会报错
         if (item.group.destroyed) {
           // @ts-ignore
-          hullInstances.current[index] = graph.createHull(
+          hullInstances[index] = graph.createHull(
             // @ts-ignore
             deepMergeCfg(defaultHullCfg, {
               id: `{Math.random()}`, // Utils.uuid(),

--- a/packages/graphin/src/components/Hull/index.tsx
+++ b/packages/graphin/src/components/Hull/index.tsx
@@ -133,8 +133,10 @@ const Hull: React.FunctionComponent<IHullProps> = props => {
     });
 
     graph.on('afterupdateitem', handleAfterUpdateItem);
+    graph.on('aftergraphrefreshposition', handleAfterUpdateItem);
     return () => {
-      graph.on('afterupdateitem', handleAfterUpdateItem);
+      graph.off('afterupdateitem', handleAfterUpdateItem);
+      graph.off('aftergraphrefreshposition', handleAfterUpdateItem);
     };
   }, [graph, options]);
 

--- a/packages/graphin/src/components/Hull/index.tsx
+++ b/packages/graphin/src/components/Hull/index.tsx
@@ -94,9 +94,13 @@ let hullInstances: any[];
 const Hull: React.FunctionComponent<IHullProps> = props => {
   const graphin = React.useContext<GraphinContextType>(GraphinContext);
   const { graph } = graphin;
+  const { options } = props;
 
   React.useEffect(() => {
-    const { options } = props;
+    // 如果options有更改，先删除再创建
+    if (hullInstances && hullInstances.length) {
+      hullInstances.forEach(item => graph.removeHull(item));
+    }
 
     hullInstances = options.map(item => {
       return graph.createHull(
@@ -132,7 +136,7 @@ const Hull: React.FunctionComponent<IHullProps> = props => {
     return () => {
       graph.on('afterupdateitem', handleAfterUpdateItem);
     };
-  }, [graph]);
+  }, [graph, options]);
 
   return null;
 };

--- a/packages/graphin/src/components/Hull/index.tsx
+++ b/packages/graphin/src/components/Hull/index.tsx
@@ -122,7 +122,7 @@ const Hull: React.FunctionComponent<IHullProps> = props => {
           hullInstances[index] = graph.createHull(
             // @ts-ignore
             deepMergeCfg(defaultHullCfg, {
-              id: `{Math.random()}`, // Utils.uuid(),
+              id: `${Math.random()}`, // Utils.uuid(),
               ...options[index],
             }),
           );


### PR DESCRIPTION
# error
更新图数据后，Hull组件updateData报错
https://codesandbox.io/s/zealous-dawn-t1h83t?file=/src/App.js


![image](https://user-images.githubusercontent.com/1826685/163330112-3fd37fe1-80ea-4839-b050-0c4936609947.png)
![image](https://user-images.githubusercontent.com/1826685/163330228-d19d3d08-6c98-4966-970f-f81940d63736.png)

# fixed
- [x] 增加判断如果当前的hull被销毁了，就重新创建一个新的
- [x] afterupdateitem会在同一时间触发多次，使用debounce将回调函数包裹一下
- [x] hull组件options更改的时候，重新create
- [x] 修复之前useEffect返回函数中取消afterupdateitem事件（这里off写成on了）
- [x] 增加监听事件aftergraphrefreshposition，防止出现布局完成后节点出现在hull范围外面的bug