### PR TITLE
fix: Fixed issue with ContextMenu not positioning correctly on first click.

### DIFF
--- a/packages/graphin-components/src/ContextMenu/index.tsx
+++ b/packages/graphin-components/src/ContextMenu/index.tsx
@@ -48,6 +48,17 @@ const ContextMenu: React.FunctionComponent<ContextMenuProps> & { Menu: typeof Me
     e.preventDefault();
     e.stopPropagation();
 
+    // Re-render before calling getBoundingClientRect
+    // on the containerRef for correct height (first click).
+    setState(preState => {
+      return {
+        ...preState,
+        visible: true,
+        x: e.canvasX,
+        y: e.canvasY
+      };
+    });
+
     const width: number = graph.get('width');
     const height: number = graph.get('height');
 


### PR DESCRIPTION
On first click `getBoundingClientRect()` returns `0` for height, due to the child elements not yet being rendered in the contextMenu. In return the correct offset of the context menu is not removed from `canvasY` when calculating the `y` value.

Before:

https://user-images.githubusercontent.com/7975925/164475620-debe3dfe-2866-4df6-9a7d-c5dc67c82600.mp4

After:

https://user-images.githubusercontent.com/7975925/164475945-3e65b389-25f2-4ddb-9819-57e151ea1c77.mp4

