### PR TITLE
Fixed loop edges positioning and labels for loop edges

### DIFF
--- a/packages/graphin/src/utils/__tests__/processEdges.test.ts
+++ b/packages/graphin/src/utils/__tests__/processEdges.test.ts
@@ -1,0 +1,91 @@
+import { IUserEdge } from '../../index';
+import processEdges from '../processEdges';
+
+describe('processEdges', () => {
+  describe('Should process edges as loops', () => {
+    let edges: IUserEdge[];
+
+    beforeEach(() => {
+      edges = [
+        {
+          source: '23a07720-b446-11e9-8592-cdfa43d74b9b',
+          target: '23a07720-b446-11e9-8592-cdfa43d74b9b',
+          data: {},
+          style: {
+            label: {
+              value: 'a',
+            },
+          },
+        },
+        {
+          source: '23a07720-b446-11e9-8592-cdfa43d74b9b',
+          target: '23a07720-b446-11e9-8592-cdfa43d74b9b',
+          data: {},
+          style: {
+            label: {
+              value: 'b',
+            },
+          },
+        },
+        {
+          source: '23a07720-b446-11e9-8592-cdfa43d74b9b',
+          target: '23a07720-b446-11e9-8592-cdfa43d74b9b',
+          data: {},
+          style: {
+            label: {
+              value: 'c',
+            },
+          },
+        },
+      ];
+    });
+
+    it('With default values', () => {
+      const newEdges = processEdges(edges);
+
+      expect(newEdges[0].style?.label?.offset).toEqual([0, -30]);
+      expect(newEdges[0].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[0].style?.keyshape?.loop?.distance).toEqual(0);
+
+      expect(newEdges[1].style?.label?.offset).toEqual([0, -50]);
+      expect(newEdges[1].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[1].style?.keyshape?.loop?.distance).toEqual(10);
+
+      expect(newEdges[2].style?.label?.offset).toEqual([0, -70]);
+      expect(newEdges[2].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[2].style?.keyshape?.loop?.distance).toEqual(20);
+    });
+
+    it('With custom loop definition', () => {
+      const newEdges = processEdges(edges, { loop: 20 });
+
+      expect(newEdges[0].style?.label?.offset).toEqual([0, -30]);
+      expect(newEdges[0].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[0].style?.keyshape?.loop?.distance).toEqual(0);
+
+      expect(newEdges[1].style?.label?.offset).toEqual([0, -70]);
+      expect(newEdges[1].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[1].style?.keyshape?.loop?.distance).toEqual(20);
+
+      expect(newEdges[2].style?.label?.offset).toEqual([0, -110]);
+      expect(newEdges[2].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[2].style?.keyshape?.loop?.distance).toEqual(40);
+    });
+
+    it('With custom loop label position', () => {
+      const newEdges = processEdges(edges, { loopLabelPosition: 0.5 });
+
+      expect(newEdges[0].style?.label?.offset).toEqual([0, -15]);
+      expect(newEdges[0].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[0].style?.keyshape?.loop?.distance).toEqual(0);
+
+      expect(newEdges[1].style?.label?.offset).toEqual([0, -35]);
+      expect(newEdges[1].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[1].style?.keyshape?.loop?.distance).toEqual(10);
+
+      expect(newEdges[2].style?.label?.offset).toEqual([0, -55]);
+      expect(newEdges[2].style?.keyshape?.type).toEqual('loop');
+      expect(newEdges[2].style?.keyshape?.loop?.distance).toEqual(20);
+    });
+  });
+});


### PR DESCRIPTION
On latest master, if I create 3 loop edges on single node, labels/edges were positioned on top of each other.

The part about loop edges was working fine on previous version and seems to be broken on `2.6.5`. So, I did the check and it seems to be the issue is with removal of `deepMix` usage on the latest master for processing edges (restored it).
If edge is loop, label position processed based on loop distance and initial offset based on default value for poly.
Did some rework on conditions and added the tests.

**BEFORE:**
![image](https://user-images.githubusercontent.com/36245750/166909352-60baa9e4-0cf6-4e5d-8442-4540fd10a143.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/36245750/166909405-90b9b87d-f114-44b3-aa3c-0f4eafb079b7.png)

There is the animation showing dynamically changed loop value. Label keeps its positioning based on loop.
![Peek 2022-05-05 11-03](https://user-images.githubusercontent.com/36245750/166910583-679dc94d-10fb-4c92-9588-56d30fca5308.gif)


