### PR TITLE
fix: Fix node size smaller than 16 producing NaN in Math.sqrt

### DIFF
--- a/packages/graphin/src/shape/graphin-line.ts
+++ b/packages/graphin/src/shape/graphin-line.ts
@@ -111,7 +111,7 @@ const processKeyshape = (cfg: EdgeConfig, style: EdgeStyle) => {
       ...loop,
     };
     const R = nodeSize / 2;
-    const dy = Math.sqrt(R ** 2 - dx ** 2);
+    const dy = Math.sqrt(Math.max(R ** 2 - dx ** 2, 0));
 
     const RX = rx || R * 2 * 0.5;
     const RY = ry || R * 2 * 0.6;


### PR DESCRIPTION
As discussed in #396 