### PR TITLE
upgrade graphin dependencies / remove unused dependencies

### DIFF
--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin",
-  "version": "2.5.0",
+  "version": "2.6.7",
   "description": "the react toolkit for graph analysis based on g6",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -19,7 +19,6 @@
     "directory": "packages/graphin"
   },
   "devDependencies": {
-    "@types/node": "latest",
     "@antv/g-base": "^0.5.9",
     "@antv/hierarchy": "^0.6.6",
     "@babel/core": "^7.16.0",
@@ -27,7 +26,9 @@
     "@testing-library/react": "^12.1.2",
     "@types/d3-quadtree": "^3.0.2",
     "@types/jest": "^27.0.3",
+    "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash-es": "^4.17.5",
+    "@types/node": "latest",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "eventemitter3": "^4.0.0",
@@ -41,8 +42,6 @@
     "prettier": "^1.18.2",
     "rimraf": "^3.0.2",
     "style-loader": "^3.3.1",
-    "svg-inline-loader": "^0.8.0",
-    "svg-path-parser": "^1.1.0",
     "ts-jest": "^27.0.7",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.2",
@@ -56,11 +55,10 @@
   "author": "AntV",
   "license": "MIT",
   "dependencies": {
-    "@antv/util": "^2.0.10",
-    "@types/lodash.clonedeep": "^4.5.6",
+    "@antv/g6": "^4.6.15",
+    "@antv/util": "^3.2.2",
     "d3-quadtree": "^3.0.1",
-    "lodash.clonedeep": "^4.5.0",
-    "@antv/g6": "^4.6.0-beta.3"
+    "lodash.clonedeep": "^4.5.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0",


### PR DESCRIPTION
## Summary
**1. Upgrade graphin's dependencies** 
`@antv/g6` - recent G6 updates ([g6 commits](https://github.com/antvis/G6/commits/master)) include performance optimizations & Combo related enhancements
For example, new combo close icons setting was introduced a few weeks ago:

https://user-images.githubusercontent.com/6743796/180625157-d897e4ce-b393-4529-af59-f422863deee7.mp4
     
`"@antv/util"`: upgraded package, verified that no methods currently used were removed or changes so its safe to upgrade
 
 2. Remove unused dependencies
 3. Move packages that don't belong in `dependencies` over to `devDependencies` since they are used at development / build time only
 
 
 ## References
 - recent G6 commits: https://github.com/antvis/G6/commits/master
