### PR TITLE
Add support for right-to-left text direction

### DIFF
--- a/packages/graphin/docs/interface/index.en-US.md
+++ b/packages/graphin/docs/interface/index.en-US.md
@@ -40,7 +40,8 @@ The most basic role of Graphin is the React component. The following table is th
 | minZoom          | `number`              | 0.2                                                   | Minimum zoom ratio                                                                                                                                               |
 | maxZoom          | `number`              | 10                                                    | Maximum zoom ratio                                                                                                                                               |
 | enabledStack     | `boolean`             | false                                                 | Whether to enable stack, that is, whether to enable redo & undo function                                                                                         |
-| maxStep          | `number`              | 10                                                    | redo & undo maximum number of steps, only works when enabledStack is true                                                                                        |
+| maxStep          | `number`              | 10                                                    | Redo & undo maximum number of steps, only works when enabledStack is true                                                                                        |
+| rtl              | `boolean`             | false                                                 | Whether text will be rendered in the right-to-left direction, useful for languages like Arabic or Hebrew                                                         | 
 
 ## How to use the graph instance in Graphin
 

--- a/packages/graphin/src/Graphin.tsx
+++ b/packages/graphin/src/Graphin.tsx
@@ -246,6 +246,9 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
     /** 装载数据 */
     this.graph.data(this.data as GraphData | TreeGraphData);
 
+    /** Setting the text direction */
+    this.setTextDirection();
+
     /** 渲染 */
     this.graph.render();
 
@@ -276,6 +279,11 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
       },
     });
   };
+
+  setTextDirection() {
+    const { dir = 'ltr' } = this.props;
+    this.graph.get('canvas').get('el').setAttribute('dir', dir);
+  }
 
   updateLayout = () => {
     this.layout.changeLayout();
@@ -325,7 +333,7 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
     const isOptionsChange = this.shouldUpdate(prevProps, 'options');
     const isThemeChange = this.shouldUpdate(prevProps, 'theme');
     // console.timeEnd('did-update');
-    const { data, layoutCache, layout } = this.props;
+    const { data, layoutCache, layout, rtl } = this.props;
     this.layoutCache = layoutCache;
     // const isGraphTypeChange = (prevProps.data as GraphinTreeData).children !== (data as GraphinTreeData).children;
 
@@ -344,6 +352,11 @@ class Graphin extends React.PureComponent<GraphinProps, GraphinState> {
     /** 配置变化 */
     if (isOptionsChange) {
       // this.updateOptions();
+
+      if (prevProps.rtl !== rtl) {
+        this.setTextDirection();
+        this.graph.render();
+      }
     }
 
     let newDragNodes: IUserNode[];

--- a/packages/graphin/src/typings/type.ts
+++ b/packages/graphin/src/typings/type.ts
@@ -186,6 +186,11 @@ export interface GraphinProps {
   [key: string]: any;
 
   // children: React.ReactChildren;
+
+  /**
+   * Text direction, to support languages like Arabic and Hebrew.
+   */
+  dir?: 'ltr' | 'rtl';
 }
 
 export interface IUserNode extends BaseNode, Partial<RestNode>, UserProperties {}


### PR DESCRIPTION
### Description

This PR adds support for the right-to-left [text direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) to support languages like Arabic or Hebrew.

### Details

Setting the `dir` attribute should be performed before the first `graph.render()` call, which is why I made this PR here on Graphin.

The added prop only includes values `'ltr' | 'rtl'`. While the `dir` attribute in normal HTML nodes also supports `'auto'`, that option doesn't seem to work in canvas in the few examples I tried.

It's also not supported by `<svg>` nodes, which is a possible target for a G6 renderer if I get it right, see the [direction](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/direction) attribute for SVG nodes.

### Help required

- I didn't try the case for SVG, since it's not in my particular use-case (I use canvas exclusively), so it would be good if someone could point me on how to test which attribute to use for each renderer (`dir` for canvas, `direction` for svg).

- I could only change the documentation for the English language, as I don't know Chinese, so help here would be appreciated.

- There was no unit test module for `Grahpin.tsx`, and I'd like to avoid building one from scratch, so help again would be good.

### Example

LTR direction (normal):
![ltr_direction](https://user-images.githubusercontent.com/16387428/182601452-9818dab6-4928-4f4c-841d-fd9f0ab4b29b.png)

RTL direction:
![rtl_direction](https://user-images.githubusercontent.com/16387428/182601465-9349a482-db51-46f6-805a-b7a552542c40.png)

### What's the weird artifact in the LTR case?

I think it's due to a bad bounding box calculation for the area to repaint, should be considered a separate issue.

Expanded video:
https://user-images.githubusercontent.com/16387428/182601923-d561e0d7-8de1-4a53-9f63-31992adb572e.mp4

Text being rendered, for reference:
داستان SVG 1.1 SE طولا ني است.
