### PR TITLE
Add selectable edges to Behaviors.ClickSelect

### DIFF
--- a/packages/graphin/src/behaviors/ClickSelect.tsx
+++ b/packages/graphin/src/behaviors/ClickSelect.tsx
@@ -13,6 +13,12 @@ const defaultConfig = {
   trigger: DEFAULT_TRIGGER,
   /** 选中的样式，默认为 selected */
   selectedState: 'selected',
+  /** Whether nodes can be selected */
+  selectNode: true,
+  /** Whether edges can be selected */
+  selectEdge: false,
+  /** Whether combos can be selected */
+  selectCombo: true,
 };
 
 export type IDragCanvasProps = Partial<typeof defaultConfig>;


### PR DESCRIPTION
### Description

This PR enables edge selection in Behaviors.ClickSelect to complement this recent PR in G6: https://github.com/antvis/G6/pull/3601.

### Explanation

It's sufficient to add values to the default config to match the ones supplied in `click-select` [at this location](https://github.com/leonardodalinky/G6/blob/45c372d8b3b72020664f1cb0253775d3804347df/packages/pc/src/behavior/click-select.ts#L13-L15). Typescript types are automatically extracted from that default object using `typeof`.