### PR TITLE
fix: passthrough opacity param for images

### DIFF
--- a/packages/graphin/src/shape/utils.ts
+++ b/packages/graphin/src/shape/utils.ts
@@ -27,6 +27,9 @@ export const setStatusStyle = (shapes: any, statusStyle: any, parseAttr: (style:
             const { attrs, ...animateOptions } = animate;
             shapeItem.animate(attrs, animateOptions);
           }
+        } else if (otherAttrs.opacity !== undefined) {
+          // Support at least transparency on images
+          shapeItem.attr({ opacity: otherAttrs.opacity });
         }
       }
     });


### PR DESCRIPTION
With this change we can update the opacity of a nodes icon like:

```javascript
const nodes = graph.getNodes();
const model = nodes[0].getModel() as NodeConfig;
 graph.focusItems([nodes[0]], true, true);

if (model && model.style) {
  model.style.icon.opacity = 0.25;
  nodes[0].update(model);
}
```

Before:

https://user-images.githubusercontent.com/2861371/191519727-93d7d64a-05d1-46e1-9fe1-a8d0baa5163f.mp4

After:

https://user-images.githubusercontent.com/2861371/191519735-fad08dd4-4f09-4ad3-8738-fb9b7ab14cef.mp4

