### PR TITLE
feat: add combo support in brush-select behavior

### DIFF
--- a/packages/graphin/src/behaviors/BrushSelect.tsx
+++ b/packages/graphin/src/behaviors/BrushSelect.tsx
@@ -23,11 +23,13 @@ const defaultConfig = {
   trigger: DEFAULT_TRIGGER,
   /** 框选过程中是否选中边，默认为 true，用户配置为 false 时，则不选中边； */
   includeEdges: true,
+  /** Whether to include combos in the selection */
+  includeCombos: false,
 };
 
 export type IDragCanvasProps = Partial<typeof defaultConfig>;
 
-const BurshSelect: React.FunctionComponent<IDragCanvasProps> = props => {
+const BrushSelect: React.FunctionComponent<IDragCanvasProps> = props => {
   useBehaviorHook({
     type: 'brush-select',
     userProps: props,
@@ -36,4 +38,4 @@ const BurshSelect: React.FunctionComponent<IDragCanvasProps> = props => {
   return null;
 };
 
-export default BurshSelect;
+export default BrushSelect;


### PR DESCRIPTION
## Description

Related PR in G6: https://github.com/antvis/G6/pull/3972

This PR adds support for selecting combos using the "brush-select" behavior. A new "includeCombos" parameter is added (default = false) to explicitly enable this effect.

Combos are selected when their midpoint is included in the rectangular brush area (similarly to edges) - most obvious when the combo is expanded:

https://user-images.githubusercontent.com/16387428/193308128-a70a47b5-1578-48b5-9950-0e7b577b33ac.mp4
