### PR TITLE
fix: Legend doesn't work when BindType='edge'

### DIFF
--- a/packages/graphin/src/components/Legend/Node.tsx
+++ b/packages/graphin/src/components/Legend/Node.tsx
@@ -48,6 +48,9 @@ const LegendNode: React.FunctionComponent<LegendChildrenProps> = props => {
       graph.setItemState(node.id, 'inactive', !checkedValue.checked);
       const { id } = node;
       const item = graph.findById(id) as INode;
+      if (item.getType() !== 'node') {
+        return;
+      }
       const edges = item.getEdges();
       edges.forEach(edge => {
         graph.setItemState(edge, 'normal', checkedValue.checked);


### PR DESCRIPTION
- fixed #471 

<Legend.Node />组件中如果绑定的type为'edge', 会触发edge没有getEdges方法的错误，导致在过滤edge的过程中只会匹配第一个匹配的边，后续的边无法匹配