### PR TITLE
fix: image opacity in icon

### DIFF
--- a/packages/graphin/src/shape/graphin-circle.ts
+++ b/packages/graphin/src/shape/graphin-circle.ts
@@ -129,6 +129,7 @@ const parseIcon = (style: NodeStyle) => {
     // @ts-ignore
     textBaseline = 'middle',
     fill,
+    fillOpacity,
     size,
     visible,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -171,6 +172,7 @@ const parseIcon = (style: NodeStyle) => {
       width,
       height,
       visible: visible !== false,
+      opacity: fillOpacity,
       ...otherAttrs,
     },
   };


### PR DESCRIPTION
- 修复 icon type 为 image 时，图片的透明度未改变