### PR TITLE
fix: fix issue of invalid autoResize

### DIFF
--- a/packages/graphin/public/main.tsx
+++ b/packages/graphin/public/main.tsx
@@ -97,6 +97,7 @@ const Demo: React.FC = () => {
       className="graphin-container"
       style={{ width: '100%', height: '100%' }}
       options={{
+        autoResize: true,
         data,
         layout,
         behaviors: ['zoom-canvas', 'drag-canvas'],

--- a/packages/graphin/src/hooks/useGraph.ts
+++ b/packages/graphin/src/hooks/useGraph.ts
@@ -16,7 +16,7 @@ export default function useGraph<P extends GraphinProps>(props: P) {
   useEffect(() => {
     if (graphRef.current || !containerRef.current) return;
 
-    const graph = new Graph({ container: containerRef.current! });
+    const graph = new Graph({ container: containerRef.current!, ...options });
     graphRef.current = graph;
 
     setIsReady(true);


### PR DESCRIPTION
- 修复 autoResize 失效的问题。在图实例化时传入 `autoResize` 参数，才能在构造函数中成功注册 resize 的事件监听