### PR TITLE
feat: implement  event bus for cross component communication

### DIFF
--- a/packages/gi-sdk/src/context/index.ts
+++ b/packages/gi-sdk/src/context/index.ts
@@ -1,3 +1,4 @@
+import type EventEmitter from '@antv/event-emitter';
 import React from 'react';
 import type RegistryManager from '../registry';
 import type StateManager from '../state';
@@ -5,6 +6,7 @@ import type StateManager from '../state';
 export interface GIContextProps {
   registry: RegistryManager;
   state: StateManager;
+  eventBus: EventEmitter;
 }
 
 export const GIContext = React.createContext<GIContextProps>(null as any);

--- a/packages/gi-sdk/src/hooks/index.ts
+++ b/packages/gi-sdk/src/hooks/index.ts
@@ -1,4 +1,6 @@
 export { useDataset } from './useDataset';
+export { useEventPublish, useEventSubscribe } from './useEvent';
+export { useEventBus } from './useEventBus';
 export { useGlobalModel } from './useGlobalModel';
 export { useGraph } from './useGraph';
 export { useGraphOptions } from './useGraphOptions';

--- a/packages/gi-sdk/src/hooks/useEvent.ts
+++ b/packages/gi-sdk/src/hooks/useEvent.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useEventBus } from './useEventBus';
+
+export const useEventSubscribe = (evt: string, callback: (...args: any[]) => void, once?: boolean) => {
+  const eventBus = useEventBus();
+
+  useEffect(() => {
+    eventBus.on(evt, callback, once);
+    return () => {
+      eventBus.off(evt, callback);
+    };
+  }, [eventBus, evt, callback, once]);
+};
+
+export const useEventPublish = () => {
+  const eventBus = useEventBus();
+
+  return eventBus.emit.bind(eventBus);
+};

--- a/packages/gi-sdk/src/hooks/useEventBus.ts
+++ b/packages/gi-sdk/src/hooks/useEventBus.ts
@@ -1,0 +1,7 @@
+import { useGIContext } from '../context';
+
+export const useEventBus = () => {
+  const { eventBus } = useGIContext();
+
+  return eventBus;
+};

--- a/packages/gi-sdk/src/index.ts
+++ b/packages/gi-sdk/src/index.ts
@@ -3,7 +3,16 @@ export { GISDK } from './GISDK';
 export { GIRuntimeApp } from './runtime';
 
 export { useGIContext } from './context';
-export { useGlobalModel, useGraph, useGraphOptions, useRegistryManger, useStateManger, useWidgetProps } from './hooks';
+export {
+  useEventPublish,
+  useEventSubscribe,
+  useGlobalModel,
+  useGraph,
+  useGraphOptions,
+  useRegistryManger,
+  useStateManger,
+  useWidgetProps,
+} from './hooks';
 
 export type { GraphContainerProps } from './components/GraphContainer';
 export type * from './context/types';

--- a/packages/gi-sdk/src/runtime/index.tsx
+++ b/packages/gi-sdk/src/runtime/index.tsx
@@ -1,3 +1,4 @@
+import EventEmitter from '@antv/event-emitter';
 import React, { memo } from 'react';
 import type { GIContextProps } from '../context';
 import { GIContext } from '../context';
@@ -34,15 +35,16 @@ export class GIRuntimeApp {
   private initRuntime(assets: AssetPackage[], initialGlobalState: GlobalModel) {
     if (!this.context.registry) this.context.registry = new RegistryManager(assets);
     if (!this.context.state) this.context.state = new StateManager(initialGlobalState);
+    if (!this.context.eventBus) this.context.eventBus = new EventEmitter();
   }
 
   private getApp() {
-    const { registry, state } = this.context;
+    const { registry, state, eventBus } = this.context;
 
     return memo((props: GIRenderProps) => {
       state?.initState(props.config);
 
-      const contextValue = { registry, state } as GIContextProps;
+      const contextValue = { registry, state, eventBus } as GIContextProps;
 
       return (
         <GIContext.Provider value={contextValue}>

--- a/packages/gi-sdk/src/runtime/types.ts
+++ b/packages/gi-sdk/src/runtime/types.ts
@@ -1,3 +1,4 @@
+import type EventEmitter from '@antv/event-emitter';
 import type RegistryManager from '../registry';
 import type StateManager from '../state';
 
@@ -10,4 +11,8 @@ export interface RuntimeContext {
    * 全局状态管理器
    */
   state?: StateManager;
+  /**
+   * 事件管理器
+   */
+  eventBus?: EventEmitter;
 }


### PR DESCRIPTION
新增了两个新的 API，用于事件订阅和发布，旨在提高资产研发过程中的事件处理能力，作为组件间通信的方式之一。

- `useEventSubscribe(evt: string, callback: (...args: any[]) => void, once?: boolean)`
- `useEventPublish()`