### PR TITLE
fix: graphin README.md usage example

### DIFF
--- a/packages/graphin/README.en-US.md
+++ b/packages/graphin/README.en-US.md
@@ -71,7 +71,6 @@ export function Demo() {
       }}
     >
     </Graphin>
-    />
   );
 }
 ```

--- a/packages/graphin/README.md
+++ b/packages/graphin/README.md
@@ -71,7 +71,6 @@ export function Demo() {
       }}
     >
     </Graphin>
-    />
   );
 }
 ```


### PR DESCRIPTION
Simple fix for README.md

delete the ` />` under `</Graphin>`:

```
import React from 'react';
import { Graphin } from '@antv/graphin';

export function Demo() {
  return (
    <Graphin
      id="my-graphin-demo"
      className="my-graphin-container"
      style={{ width: '100%', height: '100%' }}
      options={{
        data,
        node: {
          style: {
            labelText: (d) => d.id,
          },
          palette: {
            type: 'group',
            field: 'cluster',
          },
        },
        layout: {
          type: 'd3force',
          collide: {
            strength: 0.5,
          },
        },
        behaviors: ['zoom-canvas', 'drag-canvas'],
        animation: true,
      }}
    >
    </Graphin>
    />
  );
}
```