### PR TITLE
[PR]fix: graphin README.md Using hooks

### DIFF
--- a/packages/graphin/README.en-US.md
+++ b/packages/graphin/README.en-US.md
@@ -216,7 +216,7 @@ Using `useGraphin()` to access the graph instance and its state for more conveni
 
 ```jsx
 import React from 'react';
-import { Graphin, useGraphin } from '@antv/g6'';
+import { Graphin, useGraphin } from '@antv/graphin'';
 
 const CustomComponent = () => {
   const { graph, isReady } = useGraphin();

--- a/packages/graphin/README.en-US.md
+++ b/packages/graphin/README.en-US.md
@@ -71,7 +71,6 @@ export function Demo() {
       }}
     >
     </Graphin>
-    />
   );
 }
 ```

--- a/packages/graphin/README.en-US.md
+++ b/packages/graphin/README.en-US.md
@@ -216,7 +216,7 @@ Using `useGraphin()` to access the graph instance and its state for more conveni
 
 ```jsx
 import React from 'react';
-import { Graphin, useGraphin } from '@antv/graphin'';
+import { Graphin, useGraphin } from '@antv/graphin';
 
 const CustomComponent = () => {
   const { graph, isReady } = useGraphin();

--- a/packages/graphin/README.md
+++ b/packages/graphin/README.md
@@ -216,7 +216,7 @@ export function Demo() {
 
 ```jsx
 import React from 'react';
-import { Graphin, useGraphin } from '@antv/graphin'';
+import { Graphin, useGraphin } from '@antv/graphin';
 
 const CustomComponent = () => {
   const { graph, isReady } = useGraphin();

--- a/packages/graphin/README.md
+++ b/packages/graphin/README.md
@@ -71,7 +71,6 @@ export function Demo() {
       }}
     >
     </Graphin>
-    />
   );
 }
 ```

--- a/packages/graphin/README.md
+++ b/packages/graphin/README.md
@@ -216,7 +216,7 @@ export function Demo() {
 
 ```jsx
 import React from 'react';
-import { Graphin, useGraphin } from '@antv/g6'';
+import { Graphin, useGraphin } from '@antv/graphin'';
 
 const CustomComponent = () => {
   const { graph, isReady } = useGraphin();


### PR DESCRIPTION
fix graphin README.md

```
import { Graphin, useGraphin } from '@antv/g6'';
```
to
```
import { Graphin, useGraphin } from '@antv/graphin';
```